### PR TITLE
Audit follow-ups: dispatcher late-binding, biometric teardown, callId, diagnostics polish

### DIFF
--- a/src/agents/evaluation.ts
+++ b/src/agents/evaluation.ts
@@ -326,13 +326,16 @@ export const evaluate = async (
           })
         }
 
-        for (const call of calls) onEvent?.({ kind: 'tool_start', tool: call.tool })
+        for (let i = 0; i < calls.length; i++) {
+          const call = calls[i]!
+          onEvent?.({ kind: 'tool_start', tool: call.tool, callId: String(i) })
+        }
         const results = await toolExecutor(calls, triggerRoomId)
         for (let i = 0; i < results.length; i++) {
           const call = calls[i]
           const result = results[i]
           if (!call || !result) continue
-          onEvent?.({ kind: 'tool_result', tool: call.tool, success: result.success, preview: result.success ? undefined : result.error })
+          onEvent?.({ kind: 'tool_result', tool: call.tool, callId: String(i), success: result.success, preview: result.success ? undefined : result.error })
           toolTrace.push({
             tool: call.tool,
             arguments: call.arguments,

--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -13,6 +13,7 @@ import type { LLMProvider } from '../core/types/llm.ts'
 import type { LLMService } from '../llm/llm-service.ts'
 import type { MessageTarget } from '../core/types/messaging.ts'
 import type { Tool, ToolCall, ToolContext, ToolDefinition, ToolExecutor, ToolRegistry, ToolResult } from '../core/types/tool.ts'
+import { packNameFor } from '../core/types/tool-pack.ts'
 import { createAIAgent } from './ai-agent.ts'
 import type { Decision } from './ai-agent.ts'
 import { callLLM, streamLLM } from './evaluation.ts'
@@ -68,10 +69,7 @@ const createToolExecutor = (
     if (!room) return false
     const entry = registry.getEntry(toolName)
     if (!entry) return false
-    const pack = entry.source.kind === 'pack-bundled' ? entry.source.pack ?? 'local'
-      : entry.source.kind === 'skill-bundled' ? entry.source.pack ?? 'local'
-      : entry.source.kind === 'built-in' ? 'core'
-      : 'local'
+    const pack = packNameFor(entry)
     return new Set(['core', 'local', 'welcome', 'demos', ...room.getActivePacks()]).has(pack)
   }
 
@@ -205,22 +203,22 @@ export const buildToolSupport = async (
     }),
     maxResultChars,
   }
-  // Family dispatchers registered into the global registry once — getDispatchers()
-  // is idempotent and returns the same dispatcher shapes across calls. We
-  // register here (not at bootstrap) because the surface is what knows the
-  // family rules; bootstrap shouldn't depend on tool-surface internals.
+  // Family dispatcher trampolines registered into the global registry
+  // once. Each trampoline re-resolves its family's members at execute
+  // time, so packs installed AFTER this spawn become routable without
+  // re-registering. Idempotent across spawns via the has-name guard.
   const surface = createToolSurface({
     registry,
     requestedTools: allToolNames,
     getRoomActivation,
   })
-  for (const dispatcher of surface.getDispatchers()) {
+  for (const dispatcher of surface.getRegistryDispatchers()) {
     if (!registry.has(dispatcher.name)) registry.register(dispatcher)
   }
 
   // The executor must accept family-dispatcher names too — they aren't in
   // allToolNames, but they're real tools in the registry. Inject them.
-  const dispatcherNames = surface.getDispatchers().map(d => d.name)
+  const dispatcherNames = surface.getRegistryDispatchers().map(d => d.name)
   const executorAllowedNames = [...allToolNames, ...dispatcherNames.filter(n => !allToolNames.includes(n))]
   const executor = createToolExecutor(registry, executorAllowedNames, lazyContext, getAllowedToolsForRoom, getRoomActivation)
 

--- a/src/core/types/agent-eval.ts
+++ b/src/core/types/agent-eval.ts
@@ -20,8 +20,14 @@
 export type EvalEventCore =
   | { readonly kind: 'chunk'; readonly delta: string }
   | { readonly kind: 'thinking'; readonly delta: string }
-  | { readonly kind: 'tool_start'; readonly tool: string }
-  | { readonly kind: 'tool_result'; readonly tool: string; readonly success: boolean; readonly preview?: string }
+  // callId is REQUIRED on tool_start/tool_result. Unlike traceId (optional
+  // because some events are out-of-band, e.g. spawn.ts's model_fallback),
+  // tool events are emitted only from evaluation.ts's tool loop — no
+  // out-of-band sources exist. Making the field required is the
+  // compile-error forcing function that prevents a future parallel-call
+  // emit site from silently shipping without correlation.
+  | { readonly kind: 'tool_start'; readonly tool: string; readonly callId: string }
+  | { readonly kind: 'tool_result'; readonly tool: string; readonly callId: string; readonly success: boolean; readonly preview?: string }
   | { readonly kind: 'context_ready'; readonly messages: ReadonlyArray<{ readonly role: string; readonly content: string }>; readonly model: string; readonly temperature?: number; readonly toolCount: number }
   | { readonly kind: 'warning'; readonly message: string }
   | { readonly kind: 'model_fallback'; readonly preferred: string; readonly effective: string; readonly reason: string }

--- a/src/core/types/tool-pack.ts
+++ b/src/core/types/tool-pack.ts
@@ -1,0 +1,21 @@
+// Pure mapping from a ToolRegistryEntry to its owning pack name. Three
+// callers (tool-surface/index.ts, diagnostics/surface-introspect.ts,
+// agents/spawn.ts) previously each carried their own copy of this switch;
+// drift between them was a latent risk. One source of truth here.
+//
+// Mapping:
+//   built-in     → 'core'
+//   external     → 'local'
+//   pack-bundled → entry.source.pack ?? 'local'
+//   skill-bundled→ entry.source.pack ?? 'local'
+
+import type { ToolRegistryEntry } from './tool.ts'
+
+export const packNameFor = (entry: ToolRegistryEntry): string => {
+  switch (entry.source.kind) {
+    case 'built-in': return 'core'
+    case 'external': return 'local'
+    case 'pack-bundled': return entry.source.pack ?? 'local'
+    case 'skill-bundled': return entry.source.pack ?? 'local'
+  }
+}

--- a/src/diagnostics/eval-buffer.test.ts
+++ b/src/diagnostics/eval-buffer.test.ts
@@ -49,14 +49,14 @@ describe('eval-buffer', () => {
     buf.attach(addListener)
 
     fire('AI', evt({ traceId: 'tr_2', kind: 'context_ready', messages: [{ role: 'system', content: 'hi' }], model: 'gpt-4o', toolCount: 3 }))
-    fire('AI', evt({ traceId: 'tr_2', kind: 'tool_start', tool: 'biometrics_start' }))
-    fire('AI', evt({ traceId: 'tr_2', kind: 'tool_result', tool: 'biometrics_start', success: true }))
+    fire('AI', evt({ traceId: 'tr_2', kind: 'tool_start', tool: 'biometrics_start', callId: '0' }))
+    fire('AI', evt({ traceId: 'tr_2', kind: 'tool_result', tool: 'biometrics_start', callId: '0', success: true }))
     fire('AI', evt({ traceId: 'tr_2', kind: 'warning', message: 'slow start' }))
     fire('AI', evt({ traceId: 'tr_2', kind: 'eval_completed', outcome: 'respond' }))
 
     const rec = buf.getByTraceId('tr_2')
     expect(rec).toBeTruthy()
-    expect(rec?.toolCalls).toEqual([{ tool: 'biometrics_start', success: true }])
+    expect(rec?.toolCalls).toEqual([{ tool: 'biometrics_start', callId: '0', success: true }])
     expect(rec?.warnings).toEqual(['slow start'])
     expect(rec?.outcome).toBe('respond')
     expect(rec?.messages?.length).toBe(1)
@@ -78,8 +78,8 @@ describe('eval-buffer', () => {
     const { addListener, fire } = makeAddListener()
     buf.attach(addListener)
 
-    fire('AI', evt({ traceId: 'tr_a', kind: 'tool_start', tool: 'pass' }))
-    fire('Observer', evt({ traceId: 'tr_b', kind: 'tool_start', tool: 'biometrics_start' }))
+    fire('AI', evt({ traceId: 'tr_a', kind: 'tool_start', tool: 'pass', callId: '0' }))
+    fire('Observer', evt({ traceId: 'tr_b', kind: 'tool_start', tool: 'biometrics_start', callId: '0' }))
     fire('AI', evt({ traceId: 'tr_a', kind: 'eval_completed', outcome: 'pass' }))
     fire('Observer', evt({ traceId: 'tr_b', kind: 'eval_completed', outcome: 'respond' }))
 
@@ -168,11 +168,37 @@ describe('eval-buffer', () => {
     const { addListener, fire } = makeAddListener()
     buf.attach(addListener)
 
-    fire('AI', evt({ traceId: 'tr_unmatched', kind: 'tool_start', tool: 'biometrics_start' }))
+    fire('AI', evt({ traceId: 'tr_unmatched', kind: 'tool_start', tool: 'biometrics_start', callId: '0' }))
     fire('AI', evt({ traceId: 'tr_unmatched', kind: 'eval_completed', outcome: 'error' }))
 
     const rec = buf.getByTraceId('tr_unmatched')
-    expect(rec?.toolCalls).toEqual([{ tool: 'biometrics_start' }])
+    expect(rec?.toolCalls).toEqual([{ tool: 'biometrics_start', callId: '0' }])
     expect(rec?.outcome).toBe('error')
+  })
+
+  test('out-of-order results attach to the correct call by callId', () => {
+    // Forward-compat for parallel tool calls: two starts for the same tool
+    // name, results delivered second-then-first. Pre-callId code matched
+    // positionally and would mis-attribute. With callId both results land
+    // on their correct entries.
+    const buf = createEvalBuffer()
+    const { addListener, fire } = makeAddListener()
+    buf.attach(addListener)
+
+    fire('AI', evt({ traceId: 'tr_par', kind: 'tool_start', tool: 'web_search', callId: '0' }))
+    fire('AI', evt({ traceId: 'tr_par', kind: 'tool_start', tool: 'web_search', callId: '1' }))
+    // Result for the SECOND call arrives first.
+    fire('AI', evt({ traceId: 'tr_par', kind: 'tool_result', tool: 'web_search', callId: '1', success: true }))
+    fire('AI', evt({ traceId: 'tr_par', kind: 'tool_result', tool: 'web_search', callId: '0', success: false, preview: 'rate limit' }))
+    fire('AI', evt({ traceId: 'tr_par', kind: 'eval_completed', outcome: 'respond' }))
+
+    const rec = buf.getByTraceId('tr_par')
+    expect(rec?.toolCalls.length).toBe(2)
+    // Call 0 → failure with preview. Call 1 → success.
+    const c0 = rec?.toolCalls.find(t => t.callId === '0')
+    const c1 = rec?.toolCalls.find(t => t.callId === '1')
+    expect(c0?.success).toBe(false)
+    expect(c0?.preview).toBe('rate limit')
+    expect(c1?.success).toBe(true)
   })
 })

--- a/src/diagnostics/eval-buffer.ts
+++ b/src/diagnostics/eval-buffer.ts
@@ -19,6 +19,7 @@ import type { EvalEvent, OnEvalEvent } from '../core/types/agent-eval.ts'
 
 export interface ToolCallTrace {
   readonly tool: string
+  readonly callId: string
   readonly success?: boolean
   readonly preview?: string
 }
@@ -104,20 +105,21 @@ export const createEvalBuffer = (config: EvalBufferConfig = {}): EvalBuffer => {
         rec.messages = event.messages
         return
       case 'tool_start':
-        rec.toolCalls.push({ tool: event.tool })
+        rec.toolCalls.push({ tool: event.tool, callId: event.callId })
         return
       case 'tool_result': {
-        // Match the most recent open call for this tool name; pragmatic
-        // since calls within one eval are sequential.
-        for (let i = rec.toolCalls.length - 1; i >= 0; i--) {
+        // Match by callId — robust against out-of-order results when
+        // parallel tool-call execution lands. Linear scan is fine; N is
+        // small (one eval's tool calls).
+        for (let i = 0; i < rec.toolCalls.length; i++) {
           const tc = rec.toolCalls[i]
-          if (tc && tc.tool === event.tool && tc.success === undefined) {
-            rec.toolCalls[i] = { tool: event.tool, success: event.success, ...(event.preview ? { preview: event.preview } : {}) }
+          if (tc && tc.callId === event.callId && tc.success === undefined) {
+            rec.toolCalls[i] = { tool: event.tool, callId: event.callId, success: event.success, ...(event.preview ? { preview: event.preview } : {}) }
             return
           }
         }
         // Lost the corresponding start — record the result as its own entry.
-        rec.toolCalls.push({ tool: event.tool, success: event.success, ...(event.preview ? { preview: event.preview } : {}) })
+        rec.toolCalls.push({ tool: event.tool, callId: event.callId, success: event.success, ...(event.preview ? { preview: event.preview } : {}) })
         return
       }
       case 'warning':

--- a/src/diagnostics/surface-introspect.ts
+++ b/src/diagnostics/surface-introspect.ts
@@ -7,10 +7,11 @@
 // rollup. Lives in src/diagnostics/ so the tool-surface module stays a
 // leaf (no diagnostic-shaped state seeping in).
 
-import type { ToolDefinition, ToolRegistry } from '../core/types/tool.ts'
+import type { ToolDefinition } from '../core/types/tool.ts'
 import type { System } from '../main.ts'
 import { asAIAgent } from '../agents/shared.ts'
 import { createToolSurface, inferProviderFromModelRef, type GetRoomActivation } from '../tool-surface/index.ts'
+import { packNameFor } from '../core/types/tool-pack.ts'
 import { effectiveActivePackSet } from '../packs/activation.ts'
 import { estimateTokens } from '../agents/context-builder.ts'
 import { CURATED_MODELS } from '../llm/models/catalog.ts'
@@ -31,7 +32,17 @@ export interface AgentSurface {
   readonly agent: string
   readonly agentId: string
   readonly model: string
-  readonly provider: string | null
+  // The provider the agent's model is configured under (catalog lookup).
+  // This may differ from the provider actually used at eval time after
+  // router failover — see activeProvider below.
+  readonly configuredProvider: string | null
+  // The provider observed on the most recent eval for this agent
+  // (from the eval ring buffer), or null if no recent eval recorded.
+  // During failover this diverges from configuredProvider; the surface
+  // projection rules (compressed vs flat) follow configuredProvider,
+  // so a mismatch means recent evals went through a different shape
+  // than the diagnostic shows.
+  readonly activeProvider: string | null
   readonly roomId: string
   readonly roomName: string
   readonly activePacks: ReadonlyArray<string>
@@ -41,17 +52,6 @@ export interface AgentSurface {
   readonly tools: ReadonlyArray<ToolSurfaceTool>
   readonly packs: ReadonlyArray<PackRollup>
   readonly totalTokens: number
-}
-
-const packForEntry = (registry: ToolRegistry, name: string): string => {
-  const entry = registry.getEntry(name)
-  if (!entry) return 'unknown'
-  switch (entry.source.kind) {
-    case 'built-in': return 'core'
-    case 'external': return 'local'
-    case 'pack-bundled': return entry.source.pack ?? 'local'
-    case 'skill-bundled': return entry.source.pack ?? 'local'
-  }
 }
 
 export const introspectAgentSurface = (
@@ -69,7 +69,7 @@ export const introspectAgentSurface = (
 
   const config = ai.getConfig()
   const model = ai.getModel()
-  const provider = inferProviderFromModelRef(model, CURATED_MODELS) ?? null
+  const configuredProvider = inferProviderFromModelRef(model, CURATED_MODELS) ?? null
   const activePacks = effectiveActivePackSet(room)
 
   const registry = system.toolRegistry
@@ -79,11 +79,16 @@ export const introspectAgentSurface = (
   // would actually compute.
   const getRoomActivation: GetRoomActivation = (id) => system.house.getRoom(id)
   const surface = createToolSurface({ registry, requestedTools, getRoomActivation })
-  const defs: ReadonlyArray<ToolDefinition> = surface.project(roomId, provider ?? undefined)
+  const defs: ReadonlyArray<ToolDefinition> = surface.project(roomId, configuredProvider ?? undefined)
+
+  const packForName = (name: string): string => {
+    const entry = registry.getEntry(name)
+    return entry ? packNameFor(entry) : 'unknown'
+  }
 
   const tools: ToolSurfaceTool[] = defs.map(d => ({
     name: d.function.name,
-    pack: packForEntry(registry, d.function.name),
+    pack: packForName(d.function.name),
     tokens: estimateTokens(JSON.stringify(d)),
   }))
 
@@ -97,29 +102,26 @@ export const introspectAgentSurface = (
   const packs: PackRollup[] = [...packBuckets].map(([pack, b]) => ({ pack, ...b }))
     .sort((a, b) => b.tokens - a.tokens)
 
-  // Diagnostic counts: how many tools survived each stage. afterActivation
-  // is the candidate set BEFORE family compression (so users see the raw
-  // pack-filtered count vs the final dispatcher-compressed count).
-  const requestedSet = new Set(requestedTools)
-  let afterActivation = 0
-  for (const entry of registry.listEntries()) {
-    const name = entry.tool.name
-    if (!activePacks.has(packForEntry(registry, name))) continue
-    // UNION with requestedTools (matches buildCandidates).
-    afterActivation += 1
-  }
-  // Add any requestedTools that are registered but not in active-pack set
-  // (shouldn't happen with narrowed defaults, but include for completeness).
-  for (const name of requestedSet) {
-    const entry = registry.getEntry(name)
-    if (entry && !activePacks.has(packForEntry(registry, name))) afterActivation += 1
-  }
+  // afterActivation is the candidate set size BEFORE family compression —
+  // computed by the surface itself (one source of truth, no parallel
+  // re-implementation that can drift).
+  const afterActivation = surface.buildCandidates(roomId).size
+
+  // Active provider: pulled from the most recent eval for this agent. If
+  // no recent eval is recorded, null. During router failover this
+  // diverges from configuredProvider.
+  const recent = system.evalBuffer.listRecent({ limit: 1, agent: agent.name })
+  const recentModel = recent[0]?.model
+  const activeProvider = recentModel
+    ? (inferProviderFromModelRef(recentModel, CURATED_MODELS) ?? null)
+    : null
 
   return {
     agent: agent.name,
     agentId: agent.id,
     model,
-    provider,
+    configuredProvider,
+    activeProvider,
     roomId: room.profile.id,
     roomName: room.profile.name,
     activePacks: [...activePacks].sort(),

--- a/src/tool-surface/families.test.ts
+++ b/src/tool-surface/families.test.ts
@@ -9,6 +9,7 @@ import {
   ENUM_MAX_MEMBERS,
   compressFamilies,
   createFamilyDispatcher,
+  createFamilyDispatcherTrampoline,
   resolveFamilyMembers,
 } from './families.ts'
 
@@ -165,6 +166,106 @@ describe('createFamilyDispatcher', () => {
 
     await dispatcher.execute(
       { subcommand: 'probe', args: {} },
+      { callerId: 'agent-X', callerName: 'X' },
+    )
+    expect(receivedCallerId).toBe('agent-X')
+  })
+})
+
+describe('createFamilyDispatcherTrampoline (late binding)', () => {
+  const ctx = { callerId: 'test', callerName: 'Test' }
+  const family = BUILT_IN_FAMILIES.find(f => f.name === 'geo_tools')!
+
+  test('routes to a member added to the registry AFTER trampoline creation', async () => {
+    // The bug this fixes: pre-trampoline, the dispatcher captured a
+    // memberMap at registration time. Members added later were
+    // advertised by the (per-projection) LLM-facing dispatcher but the
+    // executor's registry.get() returned the stale closure → "unknown
+    // subcommand" for the new member.
+    const r = createToolRegistry()
+    r.register(tool('geo_lookup'))
+    r.register(tool('geo_add'))
+    r.register(tool('geo_remove'))
+    const dispatcher = createFamilyDispatcherTrampoline(family, r)
+
+    // Add a new family member AFTER the trampoline exists.
+    r.register(tool('geo_list_categories'))
+
+    const result = await dispatcher.execute(
+      { subcommand: 'list_categories', args: { path: '/x' } },
+      ctx,
+    )
+    expect(result.success).toBe(true)
+  })
+
+  test('returns "family disabled" when member count drops below minMembers', async () => {
+    // User-answered behaviour: an LLM that cached the family name from a
+    // prior turn could still call it after a pack uninstall. The
+    // trampoline returns a coherent refusal rather than routing into a
+    // degenerate state.
+    const r = createToolRegistry()
+    r.register(tool('geo_lookup'))
+    r.register(tool('geo_add'))
+    r.register(tool('geo_remove'))
+    const dispatcher = createFamilyDispatcherTrampoline(family, r)
+
+    // Drop two members → only 1 remains, below minMembers (3).
+    r.unregister('geo_add')
+    r.unregister('geo_remove')
+
+    const result = await dispatcher.execute(
+      { subcommand: 'lookup', args: { path: '/x' } },
+      ctx,
+    )
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('family disabled')
+    expect(result.error).toContain('1 of 3')
+  })
+
+  test('returns unknown subcommand with current-valid list (not stale)', async () => {
+    const r = createToolRegistry()
+    r.register(tool('geo_lookup'))
+    r.register(tool('geo_add'))
+    r.register(tool('geo_remove'))
+    const dispatcher = createFamilyDispatcherTrampoline(family, r)
+
+    // Add a member; the error message should include it as a valid name.
+    r.register(tool('geo_list_categories'))
+
+    const result = await dispatcher.execute(
+      { subcommand: 'nope', args: {} },
+      ctx,
+    )
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('unknown subcommand "nope"')
+    expect(result.error).toContain('list_categories')
+  })
+
+  test('rejects missing subcommand parameter', async () => {
+    const r = createToolRegistry()
+    for (const n of ['geo_lookup', 'geo_add', 'geo_remove']) r.register(tool(n))
+    const dispatcher = createFamilyDispatcherTrampoline(family, r)
+    const result = await dispatcher.execute({ args: {} }, ctx)
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('missing required `subcommand`')
+  })
+
+  test('forwards ToolContext to the routed member', async () => {
+    let receivedCallerId = ''
+    const probeTool: Tool = {
+      name: 'geo_lookup',
+      description: 'probe',
+      parameters: { type: 'object', properties: {} },
+      execute: async (_p, c) => { receivedCallerId = c.callerId; return { success: true } },
+    }
+    const r = createToolRegistry()
+    r.register(probeTool)
+    r.register(tool('geo_add'))
+    r.register(tool('geo_remove'))
+    const dispatcher = createFamilyDispatcherTrampoline(family, r)
+
+    await dispatcher.execute(
+      { subcommand: 'lookup', args: {} },
       { callerId: 'agent-X', callerName: 'X' },
     )
     expect(receivedCallerId).toBe('agent-X')

--- a/src/tool-surface/families.ts
+++ b/src/tool-surface/families.ts
@@ -38,14 +38,6 @@ export interface ToolFamily {
 // scales). Tuned for the OpenAI cost-per-enum-value vs description prose.
 export const ENUM_MAX_MEMBERS = 10
 
-// Always reserved as dispatcher names regardless of the family table; the
-// surface refuses to compress if a real tool collides with one of these
-// names (see assertNoNameCollisions). Listed here so the registration step
-// can refuse early rather than at runtime.
-export const FAMILY_DISPATCHER_NAMES: ReadonlySet<string> = new Set([
-  'fs', 'geo_tools', 'pack_admin', 'codegen_tools',
-])
-
 export const BUILT_IN_FAMILIES: ReadonlyArray<ToolFamily> = [
   {
     name: 'fs',
@@ -76,6 +68,14 @@ export const BUILT_IN_FAMILIES: ReadonlyArray<ToolFamily> = [
     minMembers: 2,
   },
 ]
+
+// Reserved dispatcher names — derived from BUILT_IN_FAMILIES so the two
+// can never drift. Used by the projection candidate filter to exclude
+// any previously-registered dispatcher (the projection re-synthesises
+// dispatchers fresh; including the stored copy caused Gemini "Duplicate
+// function declaration" failures).
+export const FAMILY_DISPATCHER_NAMES: ReadonlySet<string> =
+  new Set(BUILT_IN_FAMILIES.map(f => f.name))
 
 // Single source of truth for which tools are always retained regardless of
 // any pruning/budget logic. Layer 4 (budget cap) imports this; future
@@ -181,6 +181,76 @@ export const createFamilyDispatcher = (
           success: false,
           error: `${family.name}: unknown subcommand "${sub}". Valid: ${subcommandNames.join(', ')}`,
         }
+      }
+      const args = (params.args && typeof params.args === 'object')
+        ? (params.args as Record<string, unknown>)
+        : {}
+      try {
+        return await target.tool.execute(args, context)
+      } catch (err) {
+        return { success: false, error: err instanceof Error ? err.message : String(err) }
+      }
+    },
+  }
+}
+
+// Late-binding dispatcher: registered ONCE into the global registry at
+// agent spawn time, this Tool's execute() re-resolves the family's
+// members from the registry on every call. The previous shape
+// (createFamilyDispatcher) captured a memberMap snapshot at registration
+// time — combined with the `if (!registry.has(name)) register` guard in
+// spawn.ts, that meant a pack installed AFTER the dispatcher was first
+// registered would never become routable: the LLM-facing projection
+// (re-synthesised per-eval) advertised the new subcommand, but the
+// executor's registry.get(name) returned the stale closure.
+//
+// This trampoline closes the gap: members are resolved at execute time
+// against current registry state. Cost: one filter pass per dispatcher
+// call (registry.listEntries() is in-memory, N is small). Snapshot:
+// none — dispatcher is built-in, doesn't persist.
+//
+// minMembers is enforced at execute time too: if a pack uninstall has
+// dropped membership below threshold, the projection hides the
+// dispatcher, but a model that cached the name from a prior turn could
+// still call it. Return a coherent "family disabled" error instead of
+// routing into a degenerate state.
+export const createFamilyDispatcherTrampoline = (
+  family: ToolFamily,
+  registry: ToolRegistry,
+): Tool => {
+  return {
+    name: family.name,
+    // Description here is static — the LLM never sees this one; it sees
+    // the per-projection dispatcher built by createFamilyDispatcher from
+    // current members. This description is only visible if some tool
+    // happens to introspect the registry for help text.
+    description: `${family.description} (trampoline — late-binds to current registry members)`,
+    parameters: {
+      type: 'object',
+      properties: {
+        subcommand: { type: 'string' },
+        args: { type: 'object', additionalProperties: true },
+      },
+      required: ['subcommand', 'args'],
+    },
+    execute: async (params: Record<string, unknown>, context: ToolContext): Promise<ToolResult> => {
+      const sub = typeof params.subcommand === 'string' ? params.subcommand : ''
+      if (!sub) {
+        return { success: false, error: `${family.name}: missing required \`subcommand\` parameter` }
+      }
+      const members = registry.listEntries().filter(e => family.match(e))
+      if (members.length < family.minMembers) {
+        return {
+          success: false,
+          error: `${family.name}: family disabled — only ${members.length} of ${family.minMembers} required members registered`,
+        }
+      }
+      const memberMap = new Map<string, ToolRegistryEntry>()
+      for (const m of members) memberMap.set(family.subcommandName(m), m)
+      const target = memberMap.get(sub)
+      if (!target) {
+        const valid = [...memberMap.keys()].join(', ')
+        return { success: false, error: `${family.name}: unknown subcommand "${sub}". Valid: ${valid}` }
       }
       const args = (params.args && typeof params.args === 'object')
         ? (params.args as Record<string, unknown>)

--- a/src/tool-surface/index.ts
+++ b/src/tool-surface/index.ts
@@ -26,10 +26,17 @@
 // Stateless except for the registered synthetic dispatcher tools (one-time
 // registration at boot). No per-agent state. No snapshot impact.
 
-import type { Tool, ToolDefinition, ToolRegistry, ToolRegistryEntry } from '../core/types/tool.ts'
+import type { Tool, ToolDefinition, ToolRegistry } from '../core/types/tool.ts'
+import { packNameFor } from '../core/types/tool-pack.ts'
 import { toolsToDefinitions } from '../llm/tool-capability.ts'
 import { effectiveActivePackSet } from '../packs/activation.ts'
-import { compressFamilies, BUILT_IN_FAMILIES, FAMILY_DISPATCHER_NAMES, type ToolFamily } from './families.ts'
+import {
+  compressFamilies,
+  createFamilyDispatcherTrampoline,
+  BUILT_IN_FAMILIES,
+  FAMILY_DISPATCHER_NAMES,
+  type ToolFamily,
+} from './families.ts'
 import { isStrictProvider } from './strict-providers.ts'
 
 // Same shape as GetRoomActivation in spawn.ts — duplicated here to avoid an
@@ -39,30 +46,26 @@ export interface RoomActivation {
 }
 export type GetRoomActivation = (roomId: string) => RoomActivation | undefined
 
-// Identical to packForToolEntry in spawn.ts — duplicated here for the same
-// reason. Family dispatchers (kind: 'built-in') map to 'core' so they're
-// always pack-active. The dispatcher's own visibility-when-empty check
-// already excludes it when no member is in the active set.
-const packForToolEntry = (entry: ToolRegistryEntry): string => {
-  switch (entry.source.kind) {
-    case 'built-in': return 'core'
-    case 'external': return 'local'
-    case 'pack-bundled': return entry.source.pack ?? 'local'
-    case 'skill-bundled': return entry.source.pack ?? 'local'
-  }
-}
-
 export interface ToolSurface {
   // Project the registered tools down to the LLM-facing definition list,
-  // applying family compression (unless provider is strict), per-room pack
-  // activation, and budget cap. Pass the resolved `providerName` if known;
-  // pass undefined to conservatively skip compression.
+  // applying family compression (unless provider is strict) and per-room
+  // pack activation. Pass the resolved `providerName` if known; pass
+  // undefined to conservatively skip compression.
   readonly project: (roomId: string | undefined, providerName: string | undefined) => ReadonlyArray<ToolDefinition>
 
-  // Family dispatcher tools that need to be registered into the tool
-  // registry so the executor can route subcommand calls. Idempotent — the
-  // same dispatcher names are reused across surfaces.
-  readonly getDispatchers: () => ReadonlyArray<Tool>
+  // Late-binding dispatcher trampolines for one-time registration into
+  // the tool registry. The executor routes by registry lookup; the
+  // trampoline re-resolves the family's current members at every call,
+  // so packs installed AFTER registration become routable without
+  // re-registering. One trampoline per BUILT_IN_FAMILIES entry, regardless
+  // of current member count (the trampoline's own minMembers check
+  // handles the disabled case).
+  readonly getRegistryDispatchers: () => ReadonlyArray<Tool>
+
+  // Test/diagnostic seam: the same candidate-set construction used inside
+  // project(). Exposed so the introspection endpoint can report the exact
+  // afterActivationCount without re-implementing the rules.
+  readonly buildCandidates: (roomId: string | undefined) => ReadonlySet<string>
 }
 
 export interface CreateToolSurfaceDeps {
@@ -107,7 +110,7 @@ export const createToolSurface = (deps: CreateToolSurfaceDeps): ToolSurface => {
       if (!entry) return false
       if (FAMILY_DISPATCHER_NAMES.has(name)) return false
       if (!activeSet) return true                                    // no room → no filter
-      return activeSet.has(packForToolEntry(entry))
+      return activeSet.has(packNameFor(entry))
     }
 
     const candidates = new Set<string>()
@@ -122,7 +125,7 @@ export const createToolSurface = (deps: CreateToolSurfaceDeps): ToolSurface => {
       for (const entry of deps.registry.listEntries()) {
         const name = entry.tool.name
         if (FAMILY_DISPATCHER_NAMES.has(name)) continue
-        if (activeSet.has(packForToolEntry(entry))) candidates.add(name)
+        if (activeSet.has(packNameFor(entry))) candidates.add(name)
       }
     }
     return candidates
@@ -150,19 +153,20 @@ export const createToolSurface = (deps: CreateToolSurfaceDeps): ToolSurface => {
         ? projectFlat(candidates)
         : projectCompressed(candidates)
     },
-    getDispatchers: () => {
-      // For boot-time registration: produce dispatchers for every family
-      // whose membership currently has ≥ minMembers, regardless of the
-      // requested set. The executor needs to route any subcommand call,
-      // even if a specific agent's projection wouldn't have shown the
-      // dispatcher (e.g. the dispatcher was visible in another agent's
-      // projection and that agent called a tool by family name).
+    getRegistryDispatchers: () => {
+      // One trampoline per family in the family table — regardless of
+      // current member count. The trampoline's execute() re-resolves
+      // members at call time and enforces minMembers itself.
       //
-      // Resolved against the full registry, not the requested set.
-      const allNames = new Set(deps.registry.list().map(t => t.name))
-      const { dispatchers } = compressFamilies(deps.registry, allNames, families)
-      return dispatchers
+      // Returning all families (not just compressible-now ones) is
+      // critical: a pack installed AFTER spawn that bumps a family's
+      // membership over minMembers must be routable through the
+      // already-registered trampoline. Pre-trampoline, the boot-time
+      // snapshot omitted the dispatcher entirely if the family was
+      // below threshold, and packs added later were silently unroutable.
+      return families.map(f => createFamilyDispatcherTrampoline(f, deps.registry))
     },
+    buildCandidates,
   }
 }
 

--- a/src/tool-surface/surface.integration.test.ts
+++ b/src/tool-surface/surface.integration.test.ts
@@ -166,7 +166,7 @@ describe('regression: dispatcher round-trip never produces duplicate function de
     for (const n of ['geo_lookup', 'geo_add', 'geo_remove']) r.register(mockTool(n, 100))
     // Simulate previous spawn having registered the dispatcher already.
     const surface1 = createToolSurface({ registry: r, requestedTools: r.list().map(t => t.name) })
-    for (const d of surface1.getDispatchers()) {
+    for (const d of surface1.getRegistryDispatchers()) {
       if (!r.has(d.name)) r.register(d)
     }
     // Second spawn now sees 'geo_tools' in registry.list().
@@ -183,7 +183,7 @@ describe('regression: dispatcher round-trip never produces duplicate function de
     const r = createToolRegistry()
     for (const n of ['geo_lookup', 'geo_add', 'geo_remove']) r.register(mockTool(n, 100))
     const surface1 = createToolSurface({ registry: r, requestedTools: r.list().map(t => t.name) })
-    for (const d of surface1.getDispatchers()) {
+    for (const d of surface1.getRegistryDispatchers()) {
       if (!r.has(d.name)) r.register(d)
     }
     const surface2 = createToolSurface({ registry: r, requestedTools: r.list().map(t => t.name) })
@@ -195,15 +195,19 @@ describe('regression: dispatcher round-trip never produces duplicate function de
   })
 })
 
-describe('getDispatchers', () => {
-  test('returns one dispatcher per compressible family in the full registry', () => {
+describe('getRegistryDispatchers', () => {
+  test('returns one trampoline per family in BUILT_IN_FAMILIES, regardless of current member count', () => {
+    // Pre-trampoline this returned only "compressible-now" families; with
+    // the late-binding shape, every family gets a trampoline so packs
+    // added later become routable through the same registered dispatcher.
     const r = createToolRegistry()
     for (let i = 0; i < 4; i++) r.register(mockTool(`filesystem__t${i}`, 100))
-    for (const n of ['geo_lookup', 'geo_add', 'geo_remove']) r.register(mockTool(n, 100))
+    // geo family is BELOW minMembers (only 1) — trampoline still issued.
+    r.register(mockTool('geo_lookup', 100))
     r.register(createPassTool())
 
-    const surface = createToolSurface({ registry: r, requestedTools: ['pass'] })   // requested set is intentionally narrow
-    const dispatchers = surface.getDispatchers()
-    expect(dispatchers.map(d => d.name).sort()).toEqual(['fs', 'geo_tools'])
+    const surface = createToolSurface({ registry: r, requestedTools: ['pass'] })
+    const dispatchers = surface.getRegistryDispatchers()
+    expect(dispatchers.map(d => d.name).sort()).toEqual(['codegen_tools', 'fs', 'geo_tools', 'pack_admin'])
   })
 })

--- a/src/ui/modules/biometric/session-registry.test.ts
+++ b/src/ui/modules/biometric/session-registry.test.ts
@@ -155,6 +155,97 @@ describe('session registry', () => {
     expect(reg.get('cap_1')).toBeNull()
   })
 
+  test('setViewBinding teardown runs once on release, before session.stop', async () => {
+    const order: string[] = []
+    const session: CaptureSession = {
+      start: async () => {},
+      read: () => null,
+      stop: async () => { order.push('stop') },
+      onError: () => () => {},
+    }
+    const reg = createSessionRegistry()
+    const wrapper = makeWrapper(true) as unknown as HTMLElement
+    reg.attach('cap_1', session, wrapper)
+    reg.setViewBinding('cap_1', { teardown: () => { order.push('teardown') } })
+
+    await reg.release('cap_1', 'user')
+    expect(order).toEqual(['teardown', 'stop'])
+  })
+
+  test('setViewBinding called twice tears down the previous binding', () => {
+    const reg = createSessionRegistry()
+    const session = makeSession()
+    const wrapper = makeWrapper(true) as unknown as HTMLElement
+    reg.attach('cap_1', session, wrapper)
+    let downA = 0, downB = 0
+    reg.setViewBinding('cap_1', { teardown: () => { downA += 1 } })
+    reg.setViewBinding('cap_1', { teardown: () => { downB += 1 } })
+    // First binding torn down by the swap; second still live (release runs it).
+    expect(downA).toBe(1)
+    expect(downB).toBe(0)
+  })
+
+  test('thrown view-binding teardown does not skip session.stop', async () => {
+    const reg = createSessionRegistry()
+    const session = makeSession()
+    const wrapper = makeWrapper(true) as unknown as HTMLElement
+    reg.attach('cap_1', session, wrapper)
+    reg.setViewBinding('cap_1', { teardown: () => { throw new Error('boom') } })
+
+    await reg.release('cap_1', 'user')
+    expect(session.stopCalls()).toBe(1)
+  })
+
+  test('releaseAll releases every entry with the given reason', async () => {
+    const reg = createSessionRegistry()
+    const a = makeSession(), b = makeSession(), c = makeSession()
+    const w = makeWrapper(true) as unknown as HTMLElement
+    reg.attach('a', a, w)
+    reg.attach('b', b, w)
+    reg.attach('c', c, w)
+    const reasons: ReleaseReason[] = []
+    reg.onAllReleased((_id, r) => reasons.push(r))
+
+    await reg.releaseAll('disconnect')
+    expect(a.stopCalls()).toBe(1)
+    expect(b.stopCalls()).toBe(1)
+    expect(c.stopCalls()).toBe(1)
+    expect(reasons).toEqual(['disconnect', 'disconnect', 'disconnect'])
+  })
+
+  test('onAllReleased subscribers fire on each release; unsubscribe stops them', async () => {
+    const reg = createSessionRegistry()
+    const calls: string[] = []
+    const unsub = reg.onAllReleased((id) => calls.push(id))
+
+    const session = makeSession()
+    const wrapper = makeWrapper(true) as unknown as HTMLElement
+    reg.attach('cap_1', session, wrapper)
+    await reg.release('cap_1', 'user')
+    expect(calls).toEqual(['cap_1'])
+
+    unsub()
+    reg.attach('cap_2', makeSession(), wrapper)
+    await reg.release('cap_2', 'user')
+    expect(calls).toEqual(['cap_1'])      // no second push after unsubscribe
+  })
+
+  test('sweepOrphans fires view-binding teardown for the orphaned session', async () => {
+    const reg = createSessionRegistry()
+    const session = makeSession()
+    const wrapper = makeWrapper(true) as unknown as HTMLElement
+    reg.attach('cap_1', session, wrapper)
+    let torn = 0
+    reg.setViewBinding('cap_1', { teardown: () => { torn += 1 } })
+
+    ;(wrapper as unknown as FakeWrapper).isConnected = false
+    await reg.sweepOrphans()
+
+    expect(torn).toBe(1)
+    expect(session.stopCalls()).toBe(1)
+    expect(reg.get('cap_1')).toBeNull()
+  })
+
   test('session.stop() throwing does not stall release', async () => {
     const reg = createSessionRegistry()
     const session: CaptureSession = {

--- a/src/ui/modules/biometric/session-registry.ts
+++ b/src/ui/modules/biometric/session-registry.ts
@@ -1,9 +1,8 @@
 // Tab-scoped registry of live biometric capture sessions, keyed by
-// captureId. The MediaStream is owned here — outside the DOM widget — so
-// re-renders, room switches, and any other event that detaches the widget
-// wrapper cannot orphan a camera. A 2 s sweep timer is the unconditional
-// safety net: if the registered wrapper is no longer in the document, the
-// session is stopped.
+// captureId. The MediaStream AND the widget's view-side timers are owned
+// here — outside the DOM widget — so re-renders, room switches, and any
+// other event that detaches the widget wrapper cannot orphan a camera OR
+// leave phantom signal-push timers ticking against a dead session.
 //
 // Lifecycle invariants:
 //   - attach() registers a freshly-started session with its wrapper.
@@ -11,13 +10,20 @@
 //     fenced block was re-parsed by markdown and a new wrapper element
 //     took the old one's place). The session keeps streaming; no
 //     re-consent, no second getUserMedia.
-//   - release() is the SOLE chokepoint that stops a session. Multiple
-//     callers (Stop button, claimed-elsewhere, agent-stop, sweep, page
-//     unload) all funnel through here. Idempotent.
+//   - setViewBinding() stores a teardown callback alongside the session.
+//     Calling it again replaces (and tears down) the previous binding,
+//     so a re-mount that rewires fresh timers doesn't leak the old ones.
+//   - release() is the SOLE chokepoint that stops a session. It runs the
+//     view-binding's teardown FIRST (in its own try/catch so a thrown
+//     teardown can't prevent session.stop()), then stops the session,
+//     then fires the onRelease hook, then fans out to onAllReleased
+//     subscribers. Idempotent.
+//   - releaseAll() iterates and releases — replaces the three open-coded
+//     fan-out loops that previously walked _entries() from widget.ts.
 //   - sweepOrphans() releases any session whose wrapper has been detached.
 //     This is what makes the leak structurally impossible — no matter
 //     which mutation event fires (or doesn't), the next sweep tick stops
-//     the camera.
+//     the camera AND the view-side timers.
 //
 // The registry is tab-scoped. Cross-tab claim resolution still happens
 // over WS via biometric_capture_claimed broadcast.
@@ -32,13 +38,21 @@ export interface LiveSession {
   readonly attachedWrapper: HTMLElement | null
 }
 
+export interface ViewBinding {
+  readonly teardown: () => void
+}
+
 export interface SessionRegistry {
   readonly get: (captureId: string) => LiveSession | null
   readonly attach: (captureId: string, session: CaptureSession, wrapper: HTMLElement) => void
   readonly setWrapper: (captureId: string, wrapper: HTMLElement) => void
+  readonly setViewBinding: (captureId: string, binding: ViewBinding) => void
   readonly release: (captureId: string, reason: ReleaseReason) => Promise<void>
+  readonly releaseAll: (reason: ReleaseReason) => Promise<void>
   readonly sweepOrphans: () => Promise<void>
-  readonly _entries: () => ReadonlyArray<LiveSession>
+  // Multi-subscriber notification fired after each release completes.
+  // Returns an unsubscribe.
+  readonly onAllReleased: (cb: (captureId: string, reason: ReleaseReason) => void) => () => void
 }
 
 const SWEEP_INTERVAL_MS = 2000
@@ -57,7 +71,13 @@ export interface SessionRegistryConfig {
 }
 
 export const createSessionRegistry = (config: SessionRegistryConfig = {}): SessionRegistry => {
-  const entries = new Map<string, { session: CaptureSession; wrapper: HTMLElement | null }>()
+  interface Entry {
+    session: CaptureSession
+    wrapper: HTMLElement | null
+    viewBinding: ViewBinding | null
+  }
+  const entries = new Map<string, Entry>()
+  const subscribers = new Set<(captureId: string, reason: ReleaseReason) => void>()
   const scheduler = config.scheduler ?? {
     setInterval: (cb, ms) => globalThis.setInterval(cb, ms),
     clearInterval: (h) => globalThis.clearInterval(h as ReturnType<typeof setInterval>),
@@ -81,7 +101,7 @@ export const createSessionRegistry = (config: SessionRegistryConfig = {}): Sessi
       return e ? { captureId, session: e.session, attachedWrapper: e.wrapper } : null
     },
     attach: (captureId, session, wrapper) => {
-      entries.set(captureId, { session, wrapper })
+      entries.set(captureId, { session, wrapper, viewBinding: null })
       ensureSweeper()
       console.debug('[biometric:lifecycle] attach', { captureId })
     },
@@ -91,14 +111,39 @@ export const createSessionRegistry = (config: SessionRegistryConfig = {}): Sessi
       e.wrapper = wrapper
       console.debug('[biometric:lifecycle] setWrapper', { captureId })
     },
+    setViewBinding: (captureId, binding) => {
+      const e = entries.get(captureId)
+      if (!e) return
+      // Replace: tear down the previous binding's timers/listeners before
+      // overwriting. Re-mount paths rely on this to clean up the prior
+      // wrapper's intervals when the second wrapper rewires fresh ones.
+      if (e.viewBinding) {
+        try { e.viewBinding.teardown() } catch { /* ignore */ }
+      }
+      e.viewBinding = binding
+    },
     release: async (captureId, reason) => {
       const e = entries.get(captureId)
       if (!e) return
       entries.delete(captureId)
       console.debug('[biometric:lifecycle] release', { captureId, reason })
+      // Order matters: view-binding teardown FIRST (independent try/catch
+      // so a thrown teardown can't skip session.stop), THEN session.stop,
+      // THEN the config hook + subscribers.
+      try { e.viewBinding?.teardown() } catch { /* ignore */ }
       try { await e.session.stop() } catch { /* always swallow — release must complete */ }
       try { config.onRelease?.(captureId, reason) } catch { /* ignore */ }
+      for (const cb of subscribers) {
+        try { cb(captureId, reason) } catch { /* ignore — one subscriber's bug can't break others */ }
+      }
       stopSweeperIfEmpty()
+    },
+    releaseAll: async (reason) => {
+      // Snapshot ids before iterating so release() mutating the map is safe.
+      const ids = [...entries.keys()]
+      for (const id of ids) {
+        await registry.release(id, reason)
+      }
     },
     sweepOrphans: async () => {
       const orphans: string[] = []
@@ -110,9 +155,10 @@ export const createSessionRegistry = (config: SessionRegistryConfig = {}): Sessi
         await registry.release(id, 'unmount')
       }
     },
-    _entries: () => [...entries].map(([captureId, e]) => ({
-      captureId, session: e.session, attachedWrapper: e.wrapper,
-    })),
+    onAllReleased: (cb) => {
+      subscribers.add(cb)
+      return () => subscribers.delete(cb)
+    },
   }
 
   return registry

--- a/src/ui/modules/biometric/widget.ts
+++ b/src/ui/modules/biometric/widget.ts
@@ -47,27 +47,21 @@ const sessionRegistry = createSessionRegistry({
 })
 
 // Page-level fan-outs. Set up once at module load; cheap to keep live.
-// These trigger registry releases — the registry handles the actual
-// camera teardown.
+// These trigger registry releases — the registry handles camera teardown,
+// view-binding teardown (timers), and subscriber fan-out.
 let pageListenersAttached = false
 const ensurePageListeners = (): void => {
   if (pageListenersAttached) return
   pageListenersAttached = true
 
   document.addEventListener('samsinn:biometric-stop-all', () => {
-    for (const entry of sessionRegistry._entries()) {
-      void sessionRegistry.release(entry.captureId, 'agent')
-    }
+    void sessionRegistry.releaseAll('agent')
   })
   // pagehide covers bfcache + mobile better than beforeunload. Keep both
   // because some browsers fire only one or the other reliably.
-  const releaseAll = (): void => {
-    for (const entry of sessionRegistry._entries()) {
-      void sessionRegistry.release(entry.captureId, 'disconnect')
-    }
-  }
-  window.addEventListener('beforeunload', releaseAll)
-  window.addEventListener('pagehide', releaseAll)
+  const releaseOnUnload = (): void => { void sessionRegistry.releaseAll('disconnect') }
+  window.addEventListener('beforeunload', releaseOnUnload)
+  window.addEventListener('pagehide', releaseOnUnload)
 
   // Agent called biometrics_stop while a widget was still live. The WS
   // dispatcher fans this out as a CustomEvent keyed by captureId.
@@ -189,16 +183,19 @@ const parsePayload = (raw: string): FencedPayload | null => {
 // Wire a wrapper to an already-live session. Used both on fresh-capture
 // success and on widget re-mount for an existing captureId. Sets up the
 // view-side timers and Stop button; the session itself keeps streaming.
-// Internal: same body as wireActiveView but accepts a pre-rendered
-// ActiveUI. Used by the re-mount path so we can render the UI once,
-// retarget the live stream onto it, then wire timers + listeners.
-const wireActiveViewWithUI = (wrapper: HTMLElement, payload: FencedPayload, session: CaptureSession, startedAt: number, ui: ActiveUI): void => {
+// Returns a `teardown` callback that clears both timers — handed to the
+// registry via setViewBinding so release() owns the cleanup. The
+// registry's sweep + release paths are now the ONLY teardown routes; the
+// old `if (!wrapper.isConnected) clearInterval(...)` self-clear inside
+// the tick has been removed (it raced with release ordering).
+const wireActiveViewWithUI = (
+  wrapper: HTMLElement,
+  payload: FencedPayload,
+  session: CaptureSession,
+  startedAt: number,
+  ui: ActiveUI,
+): { teardown: () => void } => {
   const elapsedTimer = setInterval(() => {
-    if (!wrapper.isConnected) {
-      clearInterval(elapsedTimer)
-      clearInterval(pushTimer)
-      return
-    }
     const s = Math.floor((performance.now() - startedAt) / 1000)
     ui.elapsedEl.textContent = `${s}s`
     ui.signalsEl.innerHTML = buildSignalCard(session.read())
@@ -216,14 +213,13 @@ const wireActiveViewWithUI = (wrapper: HTMLElement, payload: FencedPayload, sess
   requestAnimationFrame(() => {
     try { wrapper.scrollIntoView({ block: 'end', behavior: 'smooth' }) } catch { /* ignore */ }
   })
-}
 
-// Convenience wrapper for the fresh-consent path: render the active UI
-// and wire it. Re-mount paths use wireActiveViewWithUI directly so they
-// can retarget the live stream onto the freshly-rendered video element.
-const wireActiveView = (wrapper: HTMLElement, payload: FencedPayload, session: CaptureSession, startedAt: number): void => {
-  const ui = renderActive(wrapper, payload)
-  wireActiveViewWithUI(wrapper, payload, session, startedAt, ui)
+  return {
+    teardown: () => {
+      clearInterval(elapsedTimer)
+      clearInterval(pushTimer)
+    },
+  }
 }
 
 const mountWidget = (wrapper: HTMLElement, payload: FencedPayload): void => {
@@ -242,13 +238,16 @@ const mountWidget = (wrapper: HTMLElement, payload: FencedPayload): void => {
   // (it's no longer the registered one).
   const existing = sessionRegistry.get(payload.captureId)
   if (existing) {
+    // Re-mount ordering (pinned): (1) setWrapper, (2) renderActive,
+    // (3) retarget the live stream onto the new <video>, (4) wire timers
+    // and capture teardown, (5) setViewBinding so the registry owns the
+    // new timers. Step 5 replaces the previous binding, tearing down the
+    // old wrapper's intervals.
     sessionRegistry.setWrapper(payload.captureId, wrapper)
     const ui = renderActive(wrapper, payload)
-    // Re-bind the live stream to the new video/canvas. Without this the
-    // MediaStream keeps painting the old (detached) video element and
-    // the user sees a black box in the new wrapper while REC ticks.
     void existing.session.retarget(ui.videoEl, ui.canvasEl)
-    wireActiveViewWithUI(wrapper, payload, existing.session, performance.now(), ui)
+    const binding = wireActiveViewWithUI(wrapper, payload, existing.session, performance.now(), ui)
+    sessionRegistry.setViewBinding(payload.captureId, binding)
     return
   }
 
@@ -292,11 +291,12 @@ const mountWidget = (wrapper: HTMLElement, payload: FencedPayload): void => {
 
       sessionRegistry.attach(payload.captureId, session, wrapper)
       sendWS({ type: 'biometric_capture_started', captureId: payload.captureId })
-      // Wire timers + listeners onto the ALREADY-RENDERED ui — calling
-      // wireActiveView here would re-render the wrapper and destroy the
-      // <video> element that just received the live stream, leaving a
-      // black box despite an active capture.
-      wireActiveViewWithUI(wrapper, payload, session, performance.now(), ui)
+      // Wire timers + listeners onto the ALREADY-RENDERED ui — re-rendering
+      // here would destroy the <video> element that just received the
+      // live stream, leaving a black box despite an active capture. Hand
+      // the teardown to the registry so release() owns timer cleanup.
+      const binding = wireActiveViewWithUI(wrapper, payload, session, performance.now(), ui)
+      sessionRegistry.setViewBinding(payload.captureId, binding)
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
       // Make sure no half-started session leaks if start() partly succeeded.


### PR DESCRIPTION
## Summary

Acts on the top three findings from a stress-test audit of the recent biometrics + tool-context work, plus useful nice-to-haves. Four atomic commits, sequenced so a regression bisects cleanly.

- **A — Late-binding family dispatchers** ([017d105](../../commit/017d105)). The dispatcher registered into the global registry now re-resolves its family's members from the registry at every execute() call, instead of closing over a memberMap snapshot at first spawn. Closes the boot-once-cache-with-external-inputs anti-pattern: a pack installed after spawn was advertised to the LLM but unroutable through the stale closure. Also enforces `minMembers` at execute time so an LLM that cached the family name from a prior turn gets a coherent "family disabled" refusal after a pack uninstall.
- **B + Finding 9 — Registry owns biometric view teardown** ([46667fa](../../commit/46667fa)). The widget's `elapsedTimer` + `pushTimer` are now held by the session-registry via `setViewBinding`; `release()` runs the teardown before `session.stop()` (independent try/catch so a thrown teardown can't skip camera stop). Eliminates the 250 ms phantom-signal window after release. `_entries()` escape hatch removed; `releaseAll()` + `onAllReleased()` are the public APIs.
- **C — Required `callId` on tool events** ([0a0f294](../../commit/0a0f294)). Forward-insurance against parallel tool calls. The eval-buffer was matching results to starts positionally; out-of-order delivery would silently mis-attribute. `callId` pins each result to the correct start.
- **E + F — Diagnostic accuracy** ([a3f86e0](../../commit/a3f86e0)). `/api/agents/:name/surface` now reports both `configuredProvider` (catalog lookup) and `activeProvider` (from the eval ring buffer's most recent record); divergence flags router failover. `afterActivationCount` now calls the surface's own `buildCandidates` instead of a drift-prone parallel re-implementation.
- **D — folded** into A: `FAMILY_DISPATCHER_NAMES` derived from `BUILT_IN_FAMILIES`; `packNameFor` extracted into `core/types/tool-pack.ts` and used by three sites.

Audit Finding 11 (coherence-warning dedup) deliberately dropped — speculative; the ring buffer's 50-record cap already bounds the symptom. Audit Findings 12 (JSONL spillover) and 13 (test relocation) deferred — separate concerns.

## Test plan

- [x] `bun run check` clean (server + UI)
- [x] `bun run test:unit` — 1257 pass / 0 fail (+6 new tests over baseline)
- [x] New: late-binding dispatcher routes to a member added after registration; refuses with "family disabled" when below minMembers; unknown-subcommand error lists current valid names
- [x] New: view-binding teardown fires once on release, before session.stop; thrown teardown doesn't skip session.stop; sweep also fires teardown; releaseAll fans out; onAllReleased subscriber + unsubscribe
- [x] New: eval-buffer attaches out-of-order results to the correct call by callId
- [ ] Manual: install a pack post-boot, call a new family-member subcommand, confirm it routes (production-only smoke; not run in this PR)
- [ ] Manual: open a biometric widget, click Stop, watch DevTools network — no `biometric_capture_signal` frames after the stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)