### PR TITLE
Generic wrapper-registry — close Leaflet leak, unify lifecycle

### DIFF
--- a/src/ui/modules/biometric/session-registry.test.ts
+++ b/src/ui/modules/biometric/session-registry.test.ts
@@ -1,12 +1,13 @@
-// Pure-TS unit tests for the session registry. No DOM, no MediaPipe, no
-// real getUserMedia — the registry is provider-agnostic (it accepts any
-// CaptureSession). We pass a real factory-function implementation of
-// CaptureSession that records stop() calls. Same "real interface with
-// controlled behavior" pattern as makeStubGateway in biometric-flow.test.ts;
-// not a mock.
+// Tests for the biometric specialisation of the generic wrapper-registry.
+// Acts as a contract test for that consumer — the generic surface itself
+// is covered in src/ui/modules/wrapper-registry/index.test.ts.
 //
-// The "wrapper" only needs an isConnected boolean for the sweeper. We
-// build a minimal object literal that satisfies that surface.
+// We pass a real factory-function CaptureSession (records stop() calls)
+// rather than a mock — per feedback_no_mocks.md.
+//
+// Registry entries expose fields under generic names (id, resource,
+// wrapper); biometric callers map them onto their domain at access time
+// (id ↔ captureId, resource ↔ session).
 
 import { describe, test, expect } from 'bun:test'
 import { createSessionRegistry, type ReleaseReason } from './session-registry.ts'
@@ -55,9 +56,9 @@ describe('session registry', () => {
     reg.attach('cap_1', session, wrapper)
     const entry = reg.get('cap_1')
     expect(entry).toBeTruthy()
-    expect(entry?.captureId).toBe('cap_1')
-    expect(entry?.session).toBe(session)
-    expect(entry?.attachedWrapper).toBe(wrapper)
+    expect(entry?.id).toBe('cap_1')
+    expect(entry?.resource).toBe(session)
+    expect(entry?.wrapper).toBe(wrapper)
   })
 
   test('get returns null for unknown captureId', () => {
@@ -105,7 +106,7 @@ describe('session registry', () => {
     const w2 = makeWrapper(true) as unknown as HTMLElement
     reg.attach('cap_1', session, w1)
     reg.setWrapper('cap_1', w2)
-    expect(reg.get('cap_1')?.attachedWrapper).toBe(w2)
+    expect(reg.get('cap_1')?.wrapper).toBe(w2)
     expect(session.stopCalls()).toBe(0)
   })
 

--- a/src/ui/modules/biometric/session-registry.ts
+++ b/src/ui/modules/biometric/session-registry.ts
@@ -1,65 +1,31 @@
-// Tab-scoped registry of live biometric capture sessions, keyed by
-// captureId. The MediaStream AND the widget's view-side timers are owned
-// here — outside the DOM widget — so re-renders, room switches, and any
-// other event that detaches the widget wrapper cannot orphan a camera OR
-// leave phantom signal-push timers ticking against a dead session.
+// Biometric session registry — thin specialisation of the generic
+// wrapper-registry over CaptureSession. The MediaStream AND the widget's
+// view-side timers are owned here, outside the DOM widget, so chat
+// re-renders cannot orphan a camera or leave phantom signal-push timers
+// ticking against a dead session.
 //
-// Lifecycle invariants:
-//   - attach() registers a freshly-started session with its wrapper.
-//   - setWrapper() swaps the attached wrapper on widget re-mount (the
-//     fenced block was re-parsed by markdown and a new wrapper element
-//     took the old one's place). The session keeps streaming; no
-//     re-consent, no second getUserMedia.
-//   - setViewBinding() stores a teardown callback alongside the session.
-//     Calling it again replaces (and tears down) the previous binding,
-//     so a re-mount that rewires fresh timers doesn't leak the old ones.
-//   - release() is the SOLE chokepoint that stops a session. It runs the
-//     view-binding's teardown FIRST (in its own try/catch so a thrown
-//     teardown can't prevent session.stop()), then stops the session,
-//     then fires the onRelease hook, then fans out to onAllReleased
-//     subscribers. Idempotent.
-//   - releaseAll() iterates and releases — replaces the three open-coded
-//     fan-out loops that previously walked _entries() from widget.ts.
-//   - sweepOrphans() releases any session whose wrapper has been detached.
-//     This is what makes the leak structurally impossible — no matter
-//     which mutation event fires (or doesn't), the next sweep tick stops
-//     the camera AND the view-side timers.
+// All lifecycle semantics (attach / setWrapper / setViewBinding / release /
+// releaseAll / sweepOrphans / onAllReleased) live in the generic module;
+// see src/ui/modules/wrapper-registry/index.ts for the invariants.
 //
-// The registry is tab-scoped. Cross-tab claim resolution still happens
-// over WS via biometric_capture_claimed broadcast.
+// The only biometric-specific behaviour here is:
+//   - disposeResource = (s) => s.stop() (swallow throws — release must complete)
+//   - re-export ReleaseReason under this module name so callers that
+//     thread `reason` through WS messages don't need to import the
+//     generic path
 
+import {
+  createWrapperRegistry,
+  type ReleaseReason,
+  type WrapperRegistry,
+} from '../wrapper-registry/index.ts'
 import type { CaptureSession } from '../../../biometrics/index.ts'
 
-export type ReleaseReason = 'user' | 'agent' | 'unmount' | 'disconnect' | 'error'
-
-export interface LiveSession {
-  readonly captureId: string
-  readonly session: CaptureSession
-  readonly attachedWrapper: HTMLElement | null
-}
-
-export interface ViewBinding {
-  readonly teardown: () => void
-}
-
-export interface SessionRegistry {
-  readonly get: (captureId: string) => LiveSession | null
-  readonly attach: (captureId: string, session: CaptureSession, wrapper: HTMLElement) => void
-  readonly setWrapper: (captureId: string, wrapper: HTMLElement) => void
-  readonly setViewBinding: (captureId: string, binding: ViewBinding) => void
-  readonly release: (captureId: string, reason: ReleaseReason) => Promise<void>
-  readonly releaseAll: (reason: ReleaseReason) => Promise<void>
-  readonly sweepOrphans: () => Promise<void>
-  // Multi-subscriber notification fired after each release completes.
-  // Returns an unsubscribe.
-  readonly onAllReleased: (cb: (captureId: string, reason: ReleaseReason) => void) => () => void
-}
-
-const SWEEP_INTERVAL_MS = 2000
+export type { ReleaseReason }
+export type SessionRegistry = WrapperRegistry<CaptureSession>
 
 export interface SessionRegistryConfig {
-  // Optional override for tests — when null, sweepOrphans() can still be
-  // driven manually. Production uses setInterval.
+  // Optional override for tests.
   readonly scheduler?: {
     readonly setInterval: (cb: () => void, ms: number) => unknown
     readonly clearInterval: (handle: unknown) => void
@@ -70,96 +36,10 @@ export interface SessionRegistryConfig {
   readonly onRelease?: (captureId: string, reason: ReleaseReason) => void
 }
 
-export const createSessionRegistry = (config: SessionRegistryConfig = {}): SessionRegistry => {
-  interface Entry {
-    session: CaptureSession
-    wrapper: HTMLElement | null
-    viewBinding: ViewBinding | null
-  }
-  const entries = new Map<string, Entry>()
-  const subscribers = new Set<(captureId: string, reason: ReleaseReason) => void>()
-  const scheduler = config.scheduler ?? {
-    setInterval: (cb, ms) => globalThis.setInterval(cb, ms),
-    clearInterval: (h) => globalThis.clearInterval(h as ReturnType<typeof setInterval>),
-  }
-  let sweepHandle: unknown = null
-
-  const ensureSweeper = (): void => {
-    if (sweepHandle !== null) return
-    sweepHandle = scheduler.setInterval(() => { void registry.sweepOrphans() }, SWEEP_INTERVAL_MS)
-  }
-  const stopSweeperIfEmpty = (): void => {
-    if (entries.size === 0 && sweepHandle !== null) {
-      scheduler.clearInterval(sweepHandle)
-      sweepHandle = null
-    }
-  }
-
-  const registry: SessionRegistry = {
-    get: (captureId) => {
-      const e = entries.get(captureId)
-      return e ? { captureId, session: e.session, attachedWrapper: e.wrapper } : null
-    },
-    attach: (captureId, session, wrapper) => {
-      entries.set(captureId, { session, wrapper, viewBinding: null })
-      ensureSweeper()
-      console.debug('[biometric:lifecycle] attach', { captureId })
-    },
-    setWrapper: (captureId, wrapper) => {
-      const e = entries.get(captureId)
-      if (!e) return
-      e.wrapper = wrapper
-      console.debug('[biometric:lifecycle] setWrapper', { captureId })
-    },
-    setViewBinding: (captureId, binding) => {
-      const e = entries.get(captureId)
-      if (!e) return
-      // Replace: tear down the previous binding's timers/listeners before
-      // overwriting. Re-mount paths rely on this to clean up the prior
-      // wrapper's intervals when the second wrapper rewires fresh ones.
-      if (e.viewBinding) {
-        try { e.viewBinding.teardown() } catch { /* ignore */ }
-      }
-      e.viewBinding = binding
-    },
-    release: async (captureId, reason) => {
-      const e = entries.get(captureId)
-      if (!e) return
-      entries.delete(captureId)
-      console.debug('[biometric:lifecycle] release', { captureId, reason })
-      // Order matters: view-binding teardown FIRST (independent try/catch
-      // so a thrown teardown can't skip session.stop), THEN session.stop,
-      // THEN the config hook + subscribers.
-      try { e.viewBinding?.teardown() } catch { /* ignore */ }
-      try { await e.session.stop() } catch { /* always swallow — release must complete */ }
-      try { config.onRelease?.(captureId, reason) } catch { /* ignore */ }
-      for (const cb of subscribers) {
-        try { cb(captureId, reason) } catch { /* ignore — one subscriber's bug can't break others */ }
-      }
-      stopSweeperIfEmpty()
-    },
-    releaseAll: async (reason) => {
-      // Snapshot ids before iterating so release() mutating the map is safe.
-      const ids = [...entries.keys()]
-      for (const id of ids) {
-        await registry.release(id, reason)
-      }
-    },
-    sweepOrphans: async () => {
-      const orphans: string[] = []
-      for (const [id, e] of entries) {
-        if (e.wrapper && !e.wrapper.isConnected) orphans.push(id)
-      }
-      for (const id of orphans) {
-        console.debug('[biometric:lifecycle] sweep released', { captureId: id, reason: 'unmount' })
-        await registry.release(id, 'unmount')
-      }
-    },
-    onAllReleased: (cb) => {
-      subscribers.add(cb)
-      return () => subscribers.delete(cb)
-    },
-  }
-
-  return registry
-}
+export const createSessionRegistry = (config: SessionRegistryConfig = {}): SessionRegistry =>
+  createWrapperRegistry<CaptureSession>({
+    label: 'biometric',
+    disposeResource: async (s) => { try { await s.stop() } catch { /* always swallow — release must complete */ } },
+    ...(config.scheduler ? { scheduler: config.scheduler } : {}),
+    ...(config.onRelease ? { onRelease: config.onRelease } : {}),
+  })

--- a/src/ui/modules/biometric/widget.ts
+++ b/src/ui/modules/biometric/widget.ts
@@ -245,8 +245,8 @@ const mountWidget = (wrapper: HTMLElement, payload: FencedPayload): void => {
     // old wrapper's intervals.
     sessionRegistry.setWrapper(payload.captureId, wrapper)
     const ui = renderActive(wrapper, payload)
-    void existing.session.retarget(ui.videoEl, ui.canvasEl)
-    const binding = wireActiveViewWithUI(wrapper, payload, existing.session, performance.now(), ui)
+    void existing.resource.retarget(ui.videoEl, ui.canvasEl)
+    const binding = wireActiveViewWithUI(wrapper, payload, existing.resource, performance.now(), ui)
     sessionRegistry.setViewBinding(payload.captureId, binding)
     return
   }

--- a/src/ui/modules/map/index.ts
+++ b/src/ui/modules/map/index.ts
@@ -14,6 +14,7 @@ import { parseMapSource, collectLatLngs, type ParsedMap, type EnvelopeFeature } 
 import { showMapFallback } from './fallback.ts'
 import { buildIconSpec } from './icons.ts'
 import { addPostRenderProcessor } from '../extensions/post-render-registry.ts'
+import { mapRegistry, nextMapId } from './map-registry.ts'
 
 const OSM_TILE_URL = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
 const OSM_ATTRIBUTION = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
@@ -158,7 +159,13 @@ const renderInto = async (container: HTMLElement, source: string): Promise<void>
     return
   }
 
-  buildMap(L, container, parsed, source)
+  const result = buildMap(L, container, parsed, source)
+  // Register for lifecycle ownership — sweep + release guarantee map.remove()
+  // runs when the wrapper detaches. Both call sites (chat-fence and the
+  // geodata-panel preview) route through here, so one attach() covers both.
+  if (result) {
+    mapRegistry.attach(nextMapId(), result.map, container)
+  }
 }
 
 export const renderMapBlocks = async (container: HTMLElement): Promise<void> => {

--- a/src/ui/modules/map/map-registry.test.ts
+++ b/src/ui/modules/map/map-registry.test.ts
@@ -1,0 +1,128 @@
+// Tests for the map-registry specialisation. Verifies the leak fix:
+// detached wrappers result in map.remove() calls via the generic sweep.
+// Uses a fake LeafletMap (counter object) — no real Leaflet, no DOM
+// beyond a minimal FakeWrapper with isConnected.
+
+import { describe, test, expect } from 'bun:test'
+import { createWrapperRegistry, type WrapperRegistry } from '../wrapper-registry/index.ts'
+import type { LeafletMap } from './api.ts'
+import { nextMapId } from './map-registry.ts'
+
+interface FakeWrapper { isConnected: boolean }
+const makeWrapper = (isConnected = true): FakeWrapper => ({ isConnected })
+
+interface FakeMap {
+  removeCalls: number
+  remove: () => void
+}
+const makeMap = (behaviour: 'ok' | 'throws-second' = 'ok'): FakeMap => {
+  const m: FakeMap = {
+    removeCalls: 0,
+    remove() {
+      m.removeCalls += 1
+      // Models Leaflet's non-idempotent Map.remove() — second call throws.
+      if (behaviour === 'throws-second' && m.removeCalls > 1) {
+        throw new Error('Map.remove() called twice')
+      }
+    },
+  }
+  return m
+}
+
+// Helper: build a test-scoped registry that mirrors mapRegistry's config
+// but with an injected manual scheduler so tests can drive sweep ticks.
+const makeTestMapRegistry = (): { reg: WrapperRegistry<LeafletMap>; tick: () => void } => {
+  const callbacks: Array<() => void> = []
+  const scheduler = {
+    setInterval: (cb: () => void) => { callbacks.push(cb); return callbacks.length - 1 },
+    clearInterval: (_h: unknown) => { /* no-op */ },
+  }
+  const reg = createWrapperRegistry<LeafletMap>({
+    label: 'map-test',
+    scheduler,
+    disposeResource: async (m) => { try { m.remove() } catch { /* tolerate double-dispose */ } },
+  })
+  return { reg, tick: () => { for (const cb of callbacks) cb() } }
+}
+
+describe('map-registry: leak fix', () => {
+  test('detached wrapper → sweep calls map.remove() exactly once', async () => {
+    const { reg, tick } = makeTestMapRegistry()
+    const m = makeMap()
+    const w = makeWrapper(true) as unknown as HTMLElement
+    reg.attach('map-1', m as unknown as LeafletMap, w)
+
+    ;(w as unknown as FakeWrapper).isConnected = false
+    tick()
+    await new Promise<void>(resolve => setTimeout(resolve, 0))
+
+    expect(m.removeCalls).toBe(1)
+    expect(reg.get('map-1')).toBeNull()
+  })
+
+  test('two distinct maps → both removed on a single sweep', async () => {
+    const { reg, tick } = makeTestMapRegistry()
+    const m1 = makeMap(), m2 = makeMap()
+    const w1 = makeWrapper(true) as unknown as HTMLElement
+    const w2 = makeWrapper(true) as unknown as HTMLElement
+    reg.attach('map-1', m1 as unknown as LeafletMap, w1)
+    reg.attach('map-2', m2 as unknown as LeafletMap, w2)
+
+    ;(w1 as unknown as FakeWrapper).isConnected = false
+    ;(w2 as unknown as FakeWrapper).isConnected = false
+    tick()
+    await new Promise<void>(resolve => setTimeout(resolve, 0))
+
+    expect(m1.removeCalls).toBe(1)
+    expect(m2.removeCalls).toBe(1)
+  })
+
+  test('releaseAll("disconnect") removes every map', async () => {
+    const { reg } = makeTestMapRegistry()
+    const m1 = makeMap(), m2 = makeMap()
+    const w = makeWrapper(true) as unknown as HTMLElement
+    reg.attach('map-1', m1 as unknown as LeafletMap, w)
+    reg.attach('map-2', m2 as unknown as LeafletMap, w)
+
+    await reg.releaseAll('disconnect')
+    expect(m1.removeCalls).toBe(1)
+    expect(m2.removeCalls).toBe(1)
+  })
+
+  test('Leaflet-style non-idempotent remove() — sweep + release race tolerated', async () => {
+    // Models the real Leaflet contract: second remove() throws. The
+    // registry's get-then-delete in release() guarantees disposeResource
+    // runs at most once per id, but the dispose itself swallows the
+    // throw so a concurrent release wins gracefully.
+    const { reg, tick } = makeTestMapRegistry()
+    const m = makeMap('throws-second')
+    const w = makeWrapper(true) as unknown as HTMLElement
+    reg.attach('map-1', m as unknown as LeafletMap, w)
+
+    ;(w as unknown as FakeWrapper).isConnected = false
+    // Fire sweep + explicit release concurrently — neither should reject.
+    const sweepP = (async () => { tick(); await new Promise<void>(resolve => setTimeout(resolve, 0)) })()
+    const relP = reg.release('map-1', 'user')
+    await Promise.all([sweepP, relP])
+
+    // Disposed at most once (the registry's get-then-delete is the guard).
+    expect(m.removeCalls).toBe(1)
+  })
+})
+
+describe('map-registry: id allocation', () => {
+  test('nextMapId() returns distinct ids on each call across the module', () => {
+    // Module-scope counter regression test (Finding 1.5): per-call
+    // counters could overlap and silently overwrite registry entries.
+    const a = nextMapId()
+    const b = nextMapId()
+    const c = nextMapId()
+    expect(a).not.toBe(b)
+    expect(b).not.toBe(c)
+    expect(a).not.toBe(c)
+  })
+
+  test('nextMapId() prefix is stable', () => {
+    expect(nextMapId().startsWith('map-')).toBe(true)
+  })
+})

--- a/src/ui/modules/map/map-registry.ts
+++ b/src/ui/modules/map/map-registry.ts
@@ -1,0 +1,46 @@
+// Map registry — owns LeafletMap instances outside the DOM wrapper that
+// holds them, closing a real leak: previous code created `L.map(container)`
+// and never called `.remove()`. When the chat re-rendered a message or the
+// geodata panel was closed/reopened, the Leaflet instance kept its DOM
+// listeners, tile-load callbacks, and internal references alive — slow
+// growth in the hundreds of KB per dropped map.
+//
+// This is a thin specialisation of src/ui/modules/wrapper-registry/index.ts.
+// Lifecycle semantics live there; this module supplies only:
+//   - the LeafletMap-specific disposal (map.remove())
+//   - a module-scope id counter (nextMapId) — per-call counters could
+//     produce overlapping ids that collide in entries.set() across
+//     re-renders, silently dropping a map's resource without disposing.
+//
+// Worst-case bound: sweep runs every 2000 ms (same as biometrics, so
+// timing is consistent across registries). A chat re-render that detaches
+// N map wrappers between ticks holds up to N Leaflet instances (~100 KB
+// each) until the next tick. Acceptable: bound is small in practice, and
+// a tighter sweep would burn CPU on idle pages.
+//
+// No releaseAll wiring on page-unload (unlike biometrics): the biometric
+// listeners exist to release a real OS resource (the camera). Leaflet
+// instances are pure in-page state; browser GC handles them on a real
+// page unload. The registry's only job here is in-page detach cases.
+//
+// Two sweep timers run when both biometric + map registries are active.
+// Trivial cost; documented for symmetry with biometric/session-registry.ts.
+
+import { createWrapperRegistry, type WrapperRegistry } from '../wrapper-registry/index.ts'
+import type { LeafletMap } from './api.ts'
+
+// Module-scope counter — see Finding 1.5 in the wrapper-registry stress-test.
+let mapIdCounter = 0
+export const nextMapId = (): string => `map-${++mapIdCounter}`
+
+export type MapRegistry = WrapperRegistry<LeafletMap>
+
+export const mapRegistry: MapRegistry = createWrapperRegistry<LeafletMap>({
+  label: 'map',
+  // Leaflet's Map.remove() is NOT idempotent — calling it twice throws.
+  // The registry's get-then-delete ensures release() runs at most once
+  // per id, but sweep and an explicit release could still race
+  // (sweep ticks while a Stop handler is in flight). Swallow inside
+  // dispose so the race is harmless.
+  disposeResource: async (m) => { try { m.remove() } catch { /* tolerate double-dispose */ } },
+})

--- a/src/ui/modules/wrapper-registry/index.test.ts
+++ b/src/ui/modules/wrapper-registry/index.test.ts
@@ -1,0 +1,272 @@
+// Tests for the generic wrapper-registry. Real fake resources implementing
+// a minimal contract — no mocks. The biometric specialisation
+// (session-registry.test.ts) acts as the contract test for one concrete
+// consumer; this file tests the generic surface in isolation.
+
+import { describe, test, expect } from 'bun:test'
+import { createWrapperRegistry, type ReleaseReason } from './index.ts'
+
+interface FakeWrapper { isConnected: boolean }
+const makeWrapper = (isConnected = true): FakeWrapper => ({ isConnected })
+
+interface FakeResource {
+  readonly id: string
+  readonly disposeCalls: () => number
+}
+
+const makeResource = (id: string, behaviour: 'ok' | 'throws' = 'ok'): FakeResource & { __disposed: number } => {
+  const r = { id, __disposed: 0 }
+  return Object.assign(r, {
+    disposeCalls: () => r.__disposed,
+    __throws: behaviour === 'throws',
+  })
+}
+
+const makeRegistry = (overrides: { throws?: boolean; sweepMs?: number } = {}) => {
+  const callbacks: Array<() => void> = []
+  const scheduler = {
+    setInterval: (cb: () => void) => { callbacks.push(cb); return callbacks.length - 1 },
+    clearInterval: (_h: unknown) => { /* no-op for tests */ },
+  }
+  const reg = createWrapperRegistry<ReturnType<typeof makeResource>>({
+    label: 'test',
+    scheduler,
+    ...(overrides.sweepMs !== undefined ? { sweepIntervalMs: overrides.sweepMs } : {}),
+    disposeResource: async (r) => {
+      r.__disposed += 1
+      if (overrides.throws) throw new Error('dispose blew up')
+    },
+  })
+  return { reg, tick: () => { for (const cb of callbacks) cb() }, timerCount: () => callbacks.length }
+}
+
+describe('wrapper-registry: basic lifecycle', () => {
+  test('attach then get returns the entry with generic field names', () => {
+    const { reg } = makeRegistry()
+    const r = makeResource('cap_1')
+    const w = makeWrapper(true) as unknown as HTMLElement
+    reg.attach('cap_1', r, w)
+    const e = reg.get('cap_1')
+    expect(e).toBeTruthy()
+    expect(e?.id).toBe('cap_1')
+    expect(e?.resource).toBe(r)
+    expect(e?.wrapper).toBe(w)
+  })
+
+  test('get returns null for unknown id', () => {
+    const { reg } = makeRegistry()
+    expect(reg.get('nope')).toBeNull()
+  })
+
+  test('release disposes the resource and removes the entry', async () => {
+    const { reg } = makeRegistry()
+    const r = makeResource('cap_1')
+    const w = makeWrapper(true) as unknown as HTMLElement
+    reg.attach('cap_1', r, w)
+    await reg.release('cap_1', 'user')
+    expect(r.disposeCalls()).toBe(1)
+    expect(reg.get('cap_1')).toBeNull()
+  })
+
+  test('release is idempotent — second call is a no-op', async () => {
+    const { reg } = makeRegistry()
+    const r = makeResource('cap_1')
+    reg.attach('cap_1', r, makeWrapper(true) as unknown as HTMLElement)
+    await reg.release('cap_1', 'user')
+    await reg.release('cap_1', 'agent')
+    expect(r.disposeCalls()).toBe(1)
+  })
+
+  test('disposeResource throwing does not stall release', async () => {
+    const { reg } = makeRegistry({ throws: true })
+    const r = makeResource('cap_1')
+    reg.attach('cap_1', r, makeWrapper(true) as unknown as HTMLElement)
+    await reg.release('cap_1', 'user')   // must not reject
+    expect(reg.get('cap_1')).toBeNull()
+  })
+
+  test('tolerates double-dispose: sweep + release race lands at most one dispose-with-side-effect', async () => {
+    // Models Leaflet's non-idempotent map.remove(): the registry calls
+    // disposeResource at most once because release() deletes the entry
+    // before disposing. A second release on the same id is a no-op
+    // (handled by get-then-delete check, not by the underlying resource).
+    const { reg } = makeRegistry()
+    const r = makeResource('cap_1')
+    reg.attach('cap_1', r, makeWrapper(true) as unknown as HTMLElement)
+    await Promise.all([reg.release('cap_1', 'user'), reg.release('cap_1', 'agent')])
+    expect(r.disposeCalls()).toBe(1)
+  })
+})
+
+describe('wrapper-registry: onRelease + onAllReleased', () => {
+  test('onRelease hook fires with id and reason', async () => {
+    const calls: Array<{ id: string; reason: ReleaseReason }> = []
+    const callbacks: Array<() => void> = []
+    const reg = createWrapperRegistry<ReturnType<typeof makeResource>>({
+      label: 'test',
+      scheduler: { setInterval: (cb) => { callbacks.push(cb); return 0 }, clearInterval: () => {} },
+      disposeResource: async () => {},
+      onRelease: (id, reason) => calls.push({ id, reason }),
+    })
+    reg.attach('cap_1', makeResource('cap_1'), makeWrapper(true) as unknown as HTMLElement)
+    await reg.release('cap_1', 'unmount')
+    expect(calls).toEqual([{ id: 'cap_1', reason: 'unmount' }])
+  })
+
+  test('onAllReleased subscribers fire after release; unsubscribe stops them', async () => {
+    const { reg } = makeRegistry()
+    const calls: string[] = []
+    const unsub = reg.onAllReleased((id) => calls.push(id))
+
+    reg.attach('cap_1', makeResource('cap_1'), makeWrapper(true) as unknown as HTMLElement)
+    await reg.release('cap_1', 'user')
+    expect(calls).toEqual(['cap_1'])
+
+    unsub()
+    reg.attach('cap_2', makeResource('cap_2'), makeWrapper(true) as unknown as HTMLElement)
+    await reg.release('cap_2', 'user')
+    expect(calls).toEqual(['cap_1'])
+  })
+
+  test('subscriber throwing does not break other subscribers or release', async () => {
+    const { reg } = makeRegistry()
+    const calls: string[] = []
+    reg.onAllReleased(() => { throw new Error('boom') })
+    reg.onAllReleased((id) => calls.push(id))
+    reg.attach('cap_1', makeResource('cap_1'), makeWrapper(true) as unknown as HTMLElement)
+    await reg.release('cap_1', 'user')
+    expect(calls).toEqual(['cap_1'])
+  })
+})
+
+describe('wrapper-registry: view bindings', () => {
+  test('setViewBinding teardown runs once on release, BEFORE dispose', async () => {
+    const order: string[] = []
+    const callbacks: Array<() => void> = []
+    const reg = createWrapperRegistry<{ id: string }>({
+      label: 'test',
+      scheduler: { setInterval: (cb) => { callbacks.push(cb); return 0 }, clearInterval: () => {} },
+      disposeResource: async () => { order.push('dispose') },
+    })
+    reg.attach('cap_1', { id: 'cap_1' }, makeWrapper(true) as unknown as HTMLElement)
+    reg.setViewBinding('cap_1', { teardown: () => { order.push('teardown') } })
+    await reg.release('cap_1', 'user')
+    expect(order).toEqual(['teardown', 'dispose'])
+  })
+
+  test('setViewBinding called twice tears down the previous binding', () => {
+    const { reg } = makeRegistry()
+    reg.attach('cap_1', makeResource('cap_1'), makeWrapper(true) as unknown as HTMLElement)
+    let downA = 0, downB = 0
+    reg.setViewBinding('cap_1', { teardown: () => { downA += 1 } })
+    reg.setViewBinding('cap_1', { teardown: () => { downB += 1 } })
+    expect(downA).toBe(1)
+    expect(downB).toBe(0)
+  })
+
+  test('thrown view-binding teardown does not skip dispose', async () => {
+    const { reg } = makeRegistry()
+    const r = makeResource('cap_1')
+    reg.attach('cap_1', r, makeWrapper(true) as unknown as HTMLElement)
+    reg.setViewBinding('cap_1', { teardown: () => { throw new Error('boom') } })
+    await reg.release('cap_1', 'user')
+    expect(r.disposeCalls()).toBe(1)
+  })
+
+  test('setViewBinding on unknown id is a no-op', () => {
+    const { reg } = makeRegistry()
+    expect(() => reg.setViewBinding('nope', { teardown: () => {} })).not.toThrow()
+  })
+})
+
+describe('wrapper-registry: setWrapper + sweepOrphans', () => {
+  test('setWrapper swaps the attached wrapper without disturbing the resource', () => {
+    const { reg } = makeRegistry()
+    const r = makeResource('cap_1')
+    const w1 = makeWrapper(true) as unknown as HTMLElement
+    const w2 = makeWrapper(true) as unknown as HTMLElement
+    reg.attach('cap_1', r, w1)
+    reg.setWrapper('cap_1', w2)
+    expect(reg.get('cap_1')?.wrapper).toBe(w2)
+    expect(r.disposeCalls()).toBe(0)
+  })
+
+  test('setWrapper on unknown id is a no-op', () => {
+    const { reg } = makeRegistry()
+    expect(() => reg.setWrapper('nope', makeWrapper(true) as unknown as HTMLElement)).not.toThrow()
+  })
+
+  test('sweepOrphans releases entries whose wrapper has been detached', async () => {
+    const { reg } = makeRegistry()
+    const live = makeResource('live')
+    const orphan = makeResource('orphan')
+    const liveW = makeWrapper(true) as unknown as HTMLElement
+    const orphanW = makeWrapper(true) as unknown as HTMLElement
+    reg.attach('live', live, liveW)
+    reg.attach('orphan', orphan, orphanW)
+
+    ;(orphanW as unknown as FakeWrapper).isConnected = false
+    await reg.sweepOrphans()
+
+    expect(live.disposeCalls()).toBe(0)
+    expect(orphan.disposeCalls()).toBe(1)
+    expect(reg.get('live')).toBeTruthy()
+    expect(reg.get('orphan')).toBeNull()
+  })
+
+  test('sweepOrphans fires view-binding teardown for the orphaned entry', async () => {
+    const { reg } = makeRegistry()
+    const r = makeResource('cap_1')
+    const w = makeWrapper(true) as unknown as HTMLElement
+    reg.attach('cap_1', r, w)
+    let torn = 0
+    reg.setViewBinding('cap_1', { teardown: () => { torn += 1 } })
+
+    ;(w as unknown as FakeWrapper).isConnected = false
+    await reg.sweepOrphans()
+
+    expect(torn).toBe(1)
+    expect(r.disposeCalls()).toBe(1)
+    expect(reg.get('cap_1')).toBeNull()
+  })
+
+  test('sweep timer fires via injected scheduler and stops when registry empties', async () => {
+    const { reg, tick, timerCount } = makeRegistry()
+    const r = makeResource('cap_1')
+    const w = makeWrapper(true) as unknown as HTMLElement
+    expect(timerCount()).toBe(0)
+    reg.attach('cap_1', r, w)
+    expect(timerCount()).toBe(1)
+
+    ;(w as unknown as FakeWrapper).isConnected = false
+    tick()
+    await new Promise<void>(resolve => setTimeout(resolve, 0))
+    expect(r.disposeCalls()).toBe(1)
+    expect(reg.get('cap_1')).toBeNull()
+  })
+})
+
+describe('wrapper-registry: releaseAll', () => {
+  test('releaseAll releases every entry with the given reason', async () => {
+    const { reg } = makeRegistry()
+    const a = makeResource('a'), b = makeResource('b'), c = makeResource('c')
+    const w = makeWrapper(true) as unknown as HTMLElement
+    reg.attach('a', a, w); reg.attach('b', b, w); reg.attach('c', c, w)
+    const reasons: ReleaseReason[] = []
+    reg.onAllReleased((_id, r) => reasons.push(r))
+
+    await reg.releaseAll('disconnect')
+    expect(a.disposeCalls()).toBe(1)
+    expect(b.disposeCalls()).toBe(1)
+    expect(c.disposeCalls()).toBe(1)
+    expect(reasons).toEqual(['disconnect', 'disconnect', 'disconnect'])
+    expect(reg.get('a')).toBeNull()
+  })
+
+  test('releaseAll on empty registry resolves cleanly', async () => {
+    const { reg } = makeRegistry()
+    await reg.releaseAll('disconnect')
+    // No assertion needed — just must not reject.
+    expect(true).toBe(true)
+  })
+})

--- a/src/ui/modules/wrapper-registry/index.ts
+++ b/src/ui/modules/wrapper-registry/index.ts
@@ -1,0 +1,180 @@
+// Generic wrapper-registry — owns a long-lived resource (T) outside the DOM
+// wrapper that displays it. Two consumers today:
+//
+//   biometrics (createSessionRegistry) — T = CaptureSession
+//   map        (mapRegistry)           — T = LeafletMap
+//
+// Why outside the DOM wrapper: chat re-renders detach wrappers without
+// warning. A camera left attached to a detached <video> keeps the MediaStream
+// alive (orphaned camera light). A Leaflet map left attached to a detached
+// container keeps its DOM listeners + tile callbacks + internal refs alive
+// (slow growth, hundreds of KB per dropped map). Owning the resource here
+// means we can sweep on a timer: any entry whose wrapper is no longer in
+// the document gets disposed.
+//
+// Lifecycle invariants:
+//   - attach(id, resource, wrapper) — fresh registration. starts the sweep
+//     timer (lazy) on first attach.
+//   - setWrapper(id, wrapper) — wrapper swap on re-mount; resource keeps
+//     running. Used by biometrics when markdown re-renders a fenced block.
+//   - setViewBinding(id, {teardown}) — optional. View-side teardown (e.g.
+//     timers, listeners) the registry runs BEFORE disposeResource on
+//     release. Replacing the binding tears down the previous one first.
+//     Biometrics uses this; map ignores it (uniform surface beats divergent
+//     APIs — Finding 3.5 from the stress-test).
+//   - release(id, reason) — SOLE chokepoint that disposes a resource.
+//     Ordering: viewBinding.teardown (try/swallow) → disposeResource
+//     (try/swallow) → onRelease config hook → onAllReleased subscribers.
+//     Independent try-blocks so a thrown teardown can't skip disposal.
+//   - releaseAll(reason) — release every entry; replaces open-coded
+//     fan-out loops in callers.
+//   - sweepOrphans() — release any entry whose wrapper is no longer in
+//     the document. The unconditional safety net: regardless of which
+//     mutation event fires (or doesn't), the next sweep tick cleans up.
+//
+// Two sweep timers run when both biometric + map registries are active.
+// Trivial cost; mentioned so a future reader doesn't think it's a bug.
+
+export type ReleaseReason = 'user' | 'agent' | 'unmount' | 'disconnect' | 'error'
+
+export interface ViewBinding {
+  readonly teardown: () => void
+}
+
+export interface RegistryEntry<T> {
+  readonly id: string
+  readonly resource: T
+  readonly wrapper: HTMLElement | null
+}
+
+export interface WrapperRegistry<T> {
+  readonly get: (id: string) => RegistryEntry<T> | null
+  readonly attach: (id: string, resource: T, wrapper: HTMLElement) => void
+  readonly setWrapper: (id: string, wrapper: HTMLElement) => void
+  readonly setViewBinding: (id: string, binding: ViewBinding) => void
+  readonly release: (id: string, reason: ReleaseReason) => Promise<void>
+  readonly releaseAll: (reason: ReleaseReason) => Promise<void>
+  readonly sweepOrphans: () => Promise<void>
+  readonly onAllReleased: (cb: (id: string, reason: ReleaseReason) => void) => () => void
+}
+
+export interface WrapperRegistryConfig<T> {
+  // Per-subsystem teardown of the resource itself. Forced async (one
+  // contract). disposeResource must tolerate being called when the
+  // resource is in any state — including already-disposed — because
+  // sweep and explicit release can race. Swallow throws inside the
+  // implementation rather than relying on the registry's try/catch
+  // for cleanliness; the registry's swallow is the last-line guarantee.
+  readonly disposeResource: (resource: T) => Promise<void>
+
+  // Optional per-release side effect (e.g. send a WS message).
+  // Runs AFTER disposeResource, BEFORE onAllReleased subscribers.
+  readonly onRelease?: (id: string, reason: ReleaseReason) => void
+
+  // Test seam — production uses globalThis.setInterval.
+  readonly scheduler?: {
+    readonly setInterval: (cb: () => void, ms: number) => unknown
+    readonly clearInterval: (handle: unknown) => void
+  }
+
+  // Default 2000. Tighter intervals burn CPU on idle pages.
+  readonly sweepIntervalMs?: number
+
+  // Debug label for console traces ('biometric', 'map', ...).
+  readonly label?: string
+}
+
+const DEFAULT_SWEEP_INTERVAL_MS = 2000
+
+export const createWrapperRegistry = <T>(config: WrapperRegistryConfig<T>): WrapperRegistry<T> => {
+  interface Entry {
+    resource: T
+    wrapper: HTMLElement | null
+    viewBinding: ViewBinding | null
+  }
+  const entries = new Map<string, Entry>()
+  const subscribers = new Set<(id: string, reason: ReleaseReason) => void>()
+  const scheduler = config.scheduler ?? {
+    setInterval: (cb, ms) => globalThis.setInterval(cb, ms),
+    clearInterval: (h) => globalThis.clearInterval(h as ReturnType<typeof setInterval>),
+  }
+  const sweepIntervalMs = config.sweepIntervalMs ?? DEFAULT_SWEEP_INTERVAL_MS
+  const label = config.label ?? 'wrapper'
+  let sweepHandle: unknown = null
+
+  const ensureSweeper = (): void => {
+    if (sweepHandle !== null) return
+    sweepHandle = scheduler.setInterval(() => { void registry.sweepOrphans() }, sweepIntervalMs)
+  }
+  const stopSweeperIfEmpty = (): void => {
+    if (entries.size === 0 && sweepHandle !== null) {
+      scheduler.clearInterval(sweepHandle)
+      sweepHandle = null
+    }
+  }
+
+  const registry: WrapperRegistry<T> = {
+    get: (id) => {
+      const e = entries.get(id)
+      return e ? { id, resource: e.resource, wrapper: e.wrapper } : null
+    },
+    attach: (id, resource, wrapper) => {
+      entries.set(id, { resource, wrapper, viewBinding: null })
+      ensureSweeper()
+      console.debug(`[${label}:lifecycle] attach`, { id })
+    },
+    setWrapper: (id, wrapper) => {
+      const e = entries.get(id)
+      if (!e) return
+      e.wrapper = wrapper
+      console.debug(`[${label}:lifecycle] setWrapper`, { id })
+    },
+    setViewBinding: (id, binding) => {
+      const e = entries.get(id)
+      if (!e) return
+      // Replace: tear down the previous binding first so a re-mount that
+      // rewires fresh timers doesn't leak the old ones.
+      if (e.viewBinding) {
+        try { e.viewBinding.teardown() } catch { /* ignore */ }
+      }
+      e.viewBinding = binding
+    },
+    release: async (id, reason) => {
+      const e = entries.get(id)
+      if (!e) return
+      entries.delete(id)
+      console.debug(`[${label}:lifecycle] release`, { id, reason })
+      // Independent try-blocks so a thrown teardown can't skip disposal.
+      try { e.viewBinding?.teardown() } catch { /* ignore */ }
+      try { await config.disposeResource(e.resource) } catch { /* always swallow — release must complete */ }
+      try { config.onRelease?.(id, reason) } catch { /* ignore */ }
+      for (const cb of subscribers) {
+        try { cb(id, reason) } catch { /* ignore — one subscriber's bug can't break others */ }
+      }
+      stopSweeperIfEmpty()
+    },
+    releaseAll: async (reason) => {
+      // Snapshot ids before iterating so release() mutating the map is safe.
+      const ids = [...entries.keys()]
+      for (const id of ids) {
+        await registry.release(id, reason)
+      }
+    },
+    sweepOrphans: async () => {
+      const orphans: string[] = []
+      for (const [id, e] of entries) {
+        if (e.wrapper && !e.wrapper.isConnected) orphans.push(id)
+      }
+      for (const id of orphans) {
+        console.debug(`[${label}:lifecycle] sweep released`, { id, reason: 'unmount' })
+        await registry.release(id, 'unmount')
+      }
+    },
+    onAllReleased: (cb) => {
+      subscribers.add(cb)
+      return () => subscribers.delete(cb)
+    },
+  }
+
+  return registry
+}


### PR DESCRIPTION
## Summary

Audit-driven consolidation. The biometric session-registry was the only implementation of "long-lived resource owned by a DOM wrapper, swept on a timer." Maps had the same shape and the same bug — `L.map(container)` was never `.remove()`'d when the wrapper detached. Chat re-renders and geodata-panel toggles silently piled up Leaflet instances.

- **Generic** [`wrapper-registry/index.ts`](src/ui/modules/wrapper-registry/index.ts) — attach / setWrapper / setViewBinding / release / releaseAll / sweepOrphans / onAllReleased. Independent try-blocks in `release()` so a thrown teardown can't skip resource disposal. Forced async `disposeResource` (one contract).
- **Biometric specialisation** shrinks from 165 LOC to 50 LOC; `widget.ts` changes are two field-name reads (`.session` → `.resource`, `.attachedWrapper` → `.wrapper`).
- **New map specialisation** ([`map/map-registry.ts`](src/ui/modules/map/map-registry.ts)) closes the Leaflet leak. Module-scope `nextMapId()` so per-call counters can't collide. Both render entrypoints (chat-fence `renderMapBlocks` and the geodata-panel `renderMapSource` preview) route through `renderInto` — one `attach()` call covers both call sites.

Leaflet's `Map.remove()` is not idempotent — sweep and explicit release can race; `disposeResource` swallows so the race is harmless. Comments are explicit (do not refer to it as "idempotent" — it isn't, we tolerate it).

No page-unload wiring for map (unlike biometrics, which releases the camera on `beforeunload`/`pagehide`): browser GC handles Leaflet on real page unload.

## Test plan

- [x] `bun run check` clean (server + UI tsconfig)
- [x] `bun run test:unit` — 1283 pass / 0 fail (+26 new tests over baseline)
- [x] Generic registry: 20 tests covering attach/release/sweep/setViewBinding/teardown-ordering/releaseAll/onAllReleased + double-dispose race
- [x] Biometric specialisation: 16 tests pass after field-name migration (acts as contract test)
- [x] Map specialisation: 5 tests — sweep-on-detach, two distinct maps, releaseAll, Leaflet-style non-idempotent remove race, id distinctness
- [ ] Manual: open chat with a map fence, switch rooms, confirm no console errors and no detached Leaflet instances in heap snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)