### PR TITLE
Tool surface token-cost reduction (~50% off built-in surface)

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -516,13 +516,13 @@ import type { Tool } from '../src/core/types/tool.ts'
 
 const myTool: Tool = {
   name: 'my_tool',
-  description: 'What this tool does.',
-  usage: 'When to use it and when not to.',
-  returns: 'Description of what it returns.',
+  description: 'Compute the answer.',                       // LLM-facing
+  usage: 'When humans inspect this tool, show them this.',  // UI-only (modal)
+  returns: 'Object with `answer` field.',                   // UI-only (modal)
   parameters: {
     type: 'object',
     properties: {
-      input: { type: 'string', description: 'The input value' },
+      input: { type: 'string', description: 'ISO-8601 date' },  // only when name isn't self-evident
     },
     required: ['input'],
   },
@@ -533,6 +533,13 @@ const myTool: Tool = {
 
 export default myTool
 ```
+
+### What the LLM sees (post-2026-05 cost audit)
+
+- **`description`** — sent to the LLM. Single imperative clause (≤ 200 chars typical). Second sentence ONLY for a non-obvious constraint, side-effect, or cross-tool dependency that the LLM can't infer from the first call's actual result. No "Use to…", "This tool…", "Lists all…" openers. If your return shape carries a contract the LLM must act on (e.g. paste a fence string verbatim), fold that one sentence into `description` proper.
+- **`usage` and `returns`** — *UI hints only.* Rendered in the tool-detail modal for humans inspecting a tool. NOT sent to the LLM. (Pre-2026-05 they were appended to `description`; cost audit determined the prose duplicated info the model gets from the first tool result anyway.)
+- **`parameters`** — JSON Schema. Use `default`, `enum`, `minimum`, `maximum`, `minLength`, `maxLength`, `pattern` instead of prose. All major providers honour them. Per-property `description` only when the property name doesn't self-document — keep for format hints like "ISO-3166-1 alpha-2" or "decimal degrees"; drop "Name of the room", "The X", "X to use".
+- **Cross-tool conventions** (e.g. `` ```map `` rendering, `[[AgentName]]` addressing, the geo cascade) live in the relevant skill markdown, NOT duplicated across every related tool's `description`.
 
 **Rules:**
 - Tool names must match `/^[a-zA-Z0-9_-]+$/` (no spaces; letters, digits, underscores, hyphens only)

--- a/src/core/types/tool.ts
+++ b/src/core/types/tool.ts
@@ -34,9 +34,18 @@ export interface ToolContext {
 
 export interface Tool {
   readonly name: string
+  // LLM-facing prose. Single imperative clause; second sentence only for a
+  // non-obvious constraint or cross-tool dependency. If the return shape
+  // carries a contract the LLM must act on (e.g. paste a fence verbatim),
+  // fold that sentence here — `returns` is UI-only. See src/llm/tool-capability.ts
+  // header for the full style contract.
   readonly description: string
-  readonly usage?: string           // when to use / when not to — injected into LLM context
-  readonly returns?: string         // human-readable description of the return value
+  // UI hints rendered in the tool-detail modal for humans inspecting a
+  // tool. NOT sent to the LLM (pre-2026-05 they were appended to
+  // description; cost audit determined the prose duplicated info the
+  // model gets from the first tool result anyway).
+  readonly usage?: string
+  readonly returns?: string
   readonly parameters: Record<string, unknown>  // JSON Schema for LLM
   readonly execute: (params: Record<string, unknown>, context: ToolContext) => Promise<ToolResult>
 }

--- a/src/llm/tool-capability.ts
+++ b/src/llm/tool-capability.ts
@@ -13,6 +13,44 @@
 // Gemini and Anthropic don't currently enforce this but probably will.
 // Sanitising here keeps tool authors free to write loose shapes without
 // every adapter independently catching the discrepancy.
+//
+// === LLM-facing contract (post-2026-05 cost audit) ===
+//
+//   tool.description  → goes to the LLM. Single imperative clause; ≤ 200
+//                       chars typical. Second sentence ONLY for a non-
+//                       obvious constraint, side-effect, or cross-tool
+//                       dependency that the LLM can't infer from the
+//                       first call's actual result. No "Use to…",
+//                       "This tool…" openers. If the return shape carries
+//                       a contract the LLM must act on (e.g. paste a
+//                       fence string verbatim), fold that sentence into
+//                       description proper — `returns` is UI-only.
+//
+//   tool.usage        → UI hint, surfaced in the tool-detail modal for
+//   tool.returns        humans inspecting a tool. NOT appended to the
+//                       LLM-facing description.
+//
+//   tool.parameters   → JSON Schema. Use `default`, `enum`, `minimum`,
+//                       `maximum`, `minLength`, `maxLength`, `pattern`
+//                       fields instead of prose. All major providers
+//                       honour them. Per-property `description` only when
+//                       the property name doesn't self-document (e.g.
+//                       format hints like "ISO-3166-1 alpha-2"; not
+//                       "Name of the room").
+//
+//   Cross-tool conventions (e.g. `\`\`\`map` rendering, `[[AgentName]]`
+//   addressing, geo cascade order) live in the relevant skill markdown,
+//   NOT duplicated across every related tool's description.
+//
+//   Drift in the surface size is monitored by eyeballing — a single
+//   maintainer can spot bloat in review. A previous attempt at a runtime
+//   token cap (deleted in de6c0d1) and the alternative of a CI budget
+//   test were both rejected: the cap silently dropped pack tools when
+//   registration order changed, and the CI test creates friction against
+//   every legitimate new tool without solving the real problem
+//   (LLM-correctness regression, which a token count cannot detect).
+//   LLM behaviour is verified by comparing /api/diagnostics/evals/recent
+//   outcome-rates before/after a change.
 // ============================================================================
 
 import type { Tool, ToolDefinition } from '../core/types/tool.ts'
@@ -63,12 +101,13 @@ const normaliseParameters = (
 // === Tool format conversion ===
 
 export const toolsToDefinitions = (tools: ReadonlyArray<Tool>): ReadonlyArray<ToolDefinition> =>
-  tools.map(t => {
-    let description = t.description
-    if (t.usage) description += `\nUsage: ${t.usage}`
-    if (t.returns) description += `\nReturns: ${t.returns}`
-    return {
-      type: 'function' as const,
-      function: { name: t.name, description, parameters: normaliseParameters(t.name, t.parameters) },
-    }
-  })
+  tools.map(t => ({
+    type: 'function' as const,
+    // description is the LLM-facing prose. tool.usage and tool.returns are
+    // UI hints rendered in the tool-detail modal — they're NOT sent to the
+    // LLM. (Pre-2026-05 they were appended; cost audit determined the
+    // prose duplicated information the model gets from the first tool
+    // result. For tools whose return shape carries a contract the LLM
+    // must act on, that sentence goes into `description` proper.)
+    function: { name: t.name, description: t.description, parameters: normaliseParameters(t.name, t.parameters) },
+  }))

--- a/src/tools/built-in/agent-tools.ts
+++ b/src/tools/built-in/agent-tools.ts
@@ -8,7 +8,7 @@ export const createPassTool = (): Tool => ({
   description: 'Decline to respond. Use when the message is not directed at you or has been answered.',
   parameters: {
     type: 'object',
-    properties: { reason: { type: 'string', description: 'Brief reason for passing' } },
+    properties: { reason: { type: 'string' } },
     required: ['reason'],
   },
   execute: async (params) => ({ success: true, result: params.reason as string }),
@@ -16,7 +16,7 @@ export const createPassTool = (): Tool => ({
 
 export const createListAgentsTool = (team: Team): Tool => ({
   name: 'list_agents',
-  description: 'Lists all agents in the system with their name, kind (ai/human), and model.',
+  description: 'List agents with name, kind, and model.',
   usage: 'Discover available agents before add_to_room or [[AgentName]] addressing.',
   returns: 'Array of agent profiles: { name, kind, model? }.',
   parameters: {},
@@ -32,15 +32,15 @@ export const createListAgentsTool = (team: Team): Tool => ({
 
 export const createMuteAgentTool = (team: Team, house: House): Tool => ({
   name: 'mute_agent',
-  description: 'Mutes or unmutes an agent in a room, preventing their responses from being delivered.',
+  description: 'Mute or unmute an agent in a room.',
   usage: 'Silence a misbehaving agent in one room without removing them. Use sparingly.',
   returns: '{ roomName, agentName, muted }.',
   parameters: {
     type: 'object',
     properties: {
-      roomName: { type: 'string', description: 'Name of the room' },
-      agentName: { type: 'string', description: 'Name of the agent to mute or unmute' },
-      muted: { type: 'boolean', description: 'true to mute, false to unmute' },
+      roomName: { type: 'string' },
+      agentName: { type: 'string' },
+      muted: { type: 'boolean' },
     },
     required: ['roomName', 'agentName', 'muted'],
   },
@@ -60,7 +60,7 @@ export const createMuteAgentTool = (team: Team, house: House): Tool => ({
 
 export const createGetMyContextTool = (team: Team, house: House): Tool => ({
   name: 'get_my_context',
-  description: 'Returns your own name, id, kind, and the rooms you are currently in.',
+  description: 'Return your own name, id, kind, and current rooms.',
   usage: 'Use to identify yourself, confirm your current room membership, or orient before taking structural actions.',
   returns: '{ name, id, kind, rooms: string[] }.',
   parameters: {},

--- a/src/tools/built-in/codegen-tools.ts
+++ b/src/tools/built-in/codegen-tools.ts
@@ -24,19 +24,19 @@ export const createWriteSkillTool = (
   skillsDir: string,
 ): Tool => ({
   name: 'write_skill',
-  description: 'Creates a new skill — a behavioral prompt template stored as a SKILL.md file. Skills are injected into agent context to shape how agents approach tasks.',
+  description: 'Create a SKILL.md — a behavioural prompt template injected into agent context. Bundled tools come later via write_tool.',
   usage: 'Create reusable behavioural instructions. Body is markdown. Add bundled tools later with write_tool.',
   returns: 'Object with the skill name and directory path.',
   parameters: {
     type: 'object',
     properties: {
-      name: { type: 'string', description: 'Skill name (letters, digits, underscores, hyphens only)' },
+      name: { type: 'string', pattern: '^[a-zA-Z0-9_-]+$' },
       description: { type: 'string', description: 'When this skill should be used' },
-      body: { type: 'string', description: 'Markdown body with behavioral instructions' },
+      body: { type: 'string', description: 'Markdown body' },
       scope: {
         type: 'array',
         items: { type: 'string' },
-        description: 'Room names where this skill is active. Omit for global scope.',
+        description: 'Room names. Omit for global.',
       },
     },
     required: ['name', 'description', 'body'],
@@ -92,15 +92,15 @@ export const createWriteToolTool = (
   refreshAll: RefreshAllFn,
 ): Tool => ({
   name: 'write_tool',
-  description: 'Writes a complete TypeScript tool module into a skill\'s tools/ directory. The tool is imported, validated, and registered immediately.',
+  description: 'Write a TypeScript tool module into a skill\'s tools/ dir. Imported, validated, and registered immediately.',
   usage: 'Use after generate_tool_code has produced the source code. Pass the code string directly — do not modify it. The code must be a complete .ts module that exports a tool object as default.',
   returns: 'Object with the registered tool name, skill, and file path.',
   parameters: {
     type: 'object',
     properties: {
-      skill: { type: 'string', description: 'Name of the skill to bundle this tool with (must exist)' },
-      name: { type: 'string', description: 'Tool name — used as filename (letters, digits, underscores, hyphens only)' },
-      code: { type: 'string', description: 'Complete TypeScript module source that exports a tool as default' },
+      skill: { type: 'string', description: 'Owning skill (must exist).' },
+      name: { type: 'string', pattern: '^[a-zA-Z0-9_-]+$' },
+      code: { type: 'string', description: 'Complete .ts module exporting a Tool as default.' },
     },
     required: ['skill', 'name', 'code'],
   },
@@ -174,13 +174,13 @@ export const createTestToolTool = (
   registry: ToolRegistry,
 ): Tool => ({
   name: 'test_tool',
-  description: 'Runs a registered tool with sample input and returns the result. Use to verify a tool works after creating it.',
+  description: 'Run a registered tool with sample input. Verifies a freshly-authored tool works.',
   returns: 'The tool\'s result — either { success: true, data: ... } or { success: false, error: "..." }.',
   parameters: {
     type: 'object',
     properties: {
-      name: { type: 'string', description: 'Name of the registered tool to test' },
-      input: { type: 'object', description: 'Sample parameters to pass to the tool' },
+      name: { type: 'string' },
+      input: { type: 'object' },
     },
     required: ['name', 'input'],
   },
@@ -203,7 +203,7 @@ export const createTestToolTool = (
 
 export const createListSkillsTool = (store: SkillStore): Tool => ({
   name: 'list_skills',
-  description: 'Lists all loaded skills with their descriptions, scopes, and bundled tools.',
+  description: 'List loaded skills with description, scope, and bundled tools.',
   returns: 'Array of skill objects with name, description, scope, and tools.',
   parameters: {},
   execute: async () => ({

--- a/src/tools/built-in/geo-tools.ts
+++ b/src/tools/built-in/geo-tools.ts
@@ -89,14 +89,14 @@ const renderableFor = (envelope: { view?: unknown; features: ReadonlyArray<unkno
 
 export const createGeoLookupTool = (deps?: GeoToolsDeps): Tool => ({
   name: 'geo_lookup',
-  description: 'Resolves a place name to coordinates via the cascade: local store → Overpass (OSM) → Nominatim (OSM). Use this BEFORE writing any lat/lng yourself. Categories are user-defined — call geo_list_categories first to discover what is available. Maps render INLINE via ```map fences; do NOT use add_artifact for maps.',
+  description: 'Resolve a place name to coordinates via local store → Overpass → Nominatim. Paste `data.renderable` verbatim into your reply to render the map inline.',
   usage: 'Strict-match — pass an exact name or alias. The result includes `data.renderable` — drop that string verbatim into your chat reply to render the map inline. If category is unknown, the call returns an error; ask the user to import the category first.',
   returns: '{ features: [{type:"marker", lat, lng, label, icon}], view?: {center,zoom}, source: "local"|"overpass"|"nominatim", renderable: "```map\\n...\\n```" }, or { features: [] } when nothing matched.',
   parameters: {
     type: 'object',
     properties: {
-      query: { type: 'string', description: 'Place name, alias, or address.' },
-      category: { type: 'string', description: 'A registered category id. List via geo_list_categories.' },
+      query: { type: 'string' },
+      category: { type: 'string', description: 'Registered category id (list via geo_list_categories).' },
     },
     required: ['query', 'category'],
   },
@@ -146,22 +146,22 @@ export const createGeoLookupTool = (deps?: GeoToolsDeps): Tool => ({
 
 export const createGeoAddTool = (): Tool => ({
   name: 'geo_add',
-  description: 'Adds a feature to the user-local geodata store under an existing category. Always written as verified:false (unverified). Curated (verified:true) features with the same canonical name are NOT overwritten.',
+  description: 'Add a feature to the local store under an existing category. Written as unverified; never overwrites curated entries.',
   usage: 'Use after a successful web_search or domain-knowledge claim to persist a place the cascade did not find. The category MUST already exist (call geo_list_categories). To create a new category, ask the user to use Settings → Geodata → Import.',
   returns: '{ added: boolean, replaced: boolean, id: string }. added=false when a curated entry blocked the write.',
   parameters: {
     type: 'object',
     properties: {
-      name:     { type: 'string',  description: 'Display name.' },
-      lat:      { type: 'number',  description: 'Latitude (decimal degrees).' },
-      lng:      { type: 'number',  description: 'Longitude (decimal degrees).' },
-      category: { type: 'string',  description: 'Existing category id (call geo_list_categories).' },
-      aliases:  { type: 'array',   description: 'Alternate display names / codes.', items: { type: 'string' } },
-      country:  { type: 'string',  description: 'ISO-3166-1 alpha-2 country code (optional).' },
-      operator: { type: 'string',  description: 'Operating organisation (optional).' },
-      iata:     { type: 'string',  description: 'IATA code (optional, airports).' },
-      icao:     { type: 'string',  description: 'ICAO code (optional, airports).' },
-      tags:     { type: 'array',   description: 'Free-form tags.', items: { type: 'string' } },
+      name:     { type: 'string' },
+      lat:      { type: 'number',  description: 'decimal degrees' },
+      lng:      { type: 'number',  description: 'decimal degrees' },
+      category: { type: 'string',  description: 'Existing category id.' },
+      aliases:  { type: 'array',   items: { type: 'string' } },
+      country:  { type: 'string',  description: 'ISO-3166-1 alpha-2.' },
+      operator: { type: 'string' },
+      iata:     { type: 'string',  description: 'IATA code (airports).' },
+      icao:     { type: 'string',  description: 'ICAO code (airports).' },
+      tags:     { type: 'array',   items: { type: 'string' } },
     },
     required: ['name', 'lat', 'lng', 'category'],
   },
@@ -212,14 +212,14 @@ export const createGeoAddTool = (): Tool => ({
 
 export const createGeoRemoveTool = (): Tool => ({
   name: 'geo_remove',
-  description: 'Removes a feature from the user-local geodata store. Only removes entries that are local AND unverified. Curated features and entire categories cannot be removed via this tool — that is a user-only action in Settings → Geodata.',
+  description: 'Remove an unverified local feature. Curated and non-local features are immutable from this tool.',
   usage: 'Use to clean up a wrong agent-added entry. Pass the feature id returned by geo_add or surfaced by a previous geo_lookup result.',
   returns: '{ removed: boolean }.',
   parameters: {
     type: 'object',
     properties: {
-      id:       { type: 'string', description: 'Feature id to remove.' },
-      category: { type: 'string', description: 'Category id the feature lives in.' },
+      id:       { type: 'string' },
+      category: { type: 'string' },
     },
     required: ['id', 'category'],
   },
@@ -247,7 +247,7 @@ export const createGeoRemoveTool = (): Tool => ({
 
 export const createGeoListCategoriesTool = (): Tool => ({
   name: 'geo_list_categories',
-  description: 'Lists all registered geodata categories with their id, displayName, icon, and feature count. Categories are user-defined via Settings → Geodata → Import.',
+  description: 'List registered geodata categories with id, displayName, icon, and feature count.',
   usage: 'Call this BEFORE geo_lookup, geo_add, or geo_remove to discover what categories exist. Returns an empty array on a fresh install.',
   returns: 'Array of { id, displayName, icon, featureCount, hasOsmQuery }.',
   parameters: { type: 'object', properties: {}, required: [] },
@@ -355,19 +355,19 @@ const MAX_LIMIT = 1000
 
 export const createGeoListFeaturesTool = (): Tool => ({
   name: 'geo_list_features',
-  description: 'Returns all features in a category, optionally filtered by country / operator / name-substring / tag. Use this when the user wants to see many features at once on a map (e.g. "show all Norwegian oil platforms"). One call replaces the lookup-each-name dance. Maps render INLINE via ```map fences; do NOT use add_artifact for maps.',
+  description: 'List features in a category, optionally filtered by country / operator / name-substring / tag. Paste `data.renderable` verbatim into your reply to render the map inline.',
   usage: 'Pass `category` (exact id) OR `categoryHint` (e.g. "oil platforms"). On ambiguous hint, the call errors with the candidate ids so you can clarify with the user. Filters compose (AND): country=ISO-3166-1-alpha-2, operator=substring, nameContains=substring on name+aliases, tag=exact match. Drop `data.renderable` verbatim into your chat reply to render the map inline.',
   returns: '{ features: [...], view?: {center, zoom}, count, totalMatched, truncated, category, source: "merged", renderable: "```map\\n{...}\\n```" }, or { success:false, error, candidates? } on ambiguity.',
   parameters: {
     type: 'object',
     properties: {
-      category:      { type: 'string', description: 'Exact registered category id.' },
-      categoryHint:  { type: 'string', description: 'Substring against id or displayName when you don\'t know the exact id. Errors with candidates on ambiguity.' },
-      country:       { type: 'string', description: 'ISO-3166-1 alpha-2 country code (e.g. "NO" for Norway).' },
-      operator:      { type: 'string', description: 'Operator substring (case-insensitive).' },
-      nameContains:  { type: 'string', description: 'Substring against feature name + aliases.' },
-      tag:           { type: 'string', description: 'Exact tag match (case-insensitive).' },
-      limit:         { type: 'number', description: `Default ${DEFAULT_LIMIT}, hard cap ${MAX_LIMIT}.` },
+      category:      { type: 'string' },
+      categoryHint:  { type: 'string', description: 'Substring against id or displayName; errors with candidates on ambiguity.' },
+      country:       { type: 'string', description: 'ISO-3166-1 alpha-2.' },
+      operator:      { type: 'string', description: 'Substring, case-insensitive.' },
+      nameContains:  { type: 'string', description: 'Matches name + aliases.' },
+      tag:           { type: 'string' },
+      limit:         { type: 'number', default: DEFAULT_LIMIT, maximum: MAX_LIMIT },
     },
     required: [],
   },

--- a/src/tools/built-in/room-tools.ts
+++ b/src/tools/built-in/room-tools.ts
@@ -8,7 +8,7 @@ type RemoveRoomFn = (roomId: string) => boolean
 
 export const createListRoomsTool = (house: House): Tool => ({
   name: 'list_rooms',
-  description: 'Lists all rooms with their names.',
+  description: 'List rooms.',
   usage: 'Use to discover available rooms before joining, posting to, or routing messages. Check here first when you need to know which rooms exist.',
   returns: 'Array of room name strings.',
   parameters: {},
@@ -20,14 +20,14 @@ export const createListRoomsTool = (house: House): Tool => ({
 
 export const createCreateRoomTool = (house: House, addAgentToRoom: AddToRoomFn): Tool => ({
   name: 'create_room',
-  description: 'Creates a new room and automatically adds the calling agent to it.',
+  description: 'Create a room and add yourself to it. Returns the assigned name (may differ on conflict).',
   usage: 'Set up a workspace. The calling agent is added automatically. Optional roomPrompt sets purpose/constraints.',
   returns: 'Object with "name" (assigned, may differ if conflict), "id", and "renamed" (true if the name was adjusted).',
   parameters: {
     type: 'object',
     properties: {
-      name: { type: 'string', description: 'Name for the new room' },
-      roomPrompt: { type: 'string', description: 'Optional system prompt for the room' },
+      name: { type: 'string' },
+      roomPrompt: { type: 'string' },
     },
     required: ['name'],
   },
@@ -54,14 +54,12 @@ export const createCreateRoomTool = (house: House, addAgentToRoom: AddToRoomFn):
 
 export const createDeleteRoomTool = (removeRoom: RemoveRoomFn, house: House): Tool => ({
   name: 'delete_room',
-  description: 'Permanently deletes a room and all its messages.',
+  description: 'Permanently delete a room and its messages. Irreversible — prefer remove_from_room if unsure.',
   usage: 'Use only to remove rooms that are fully finished and no longer needed. This is irreversible — all messages are lost. Prefer leaving a room over deleting it if unsure.',
   returns: 'Confirmation with the name of the removed room.',
   parameters: {
     type: 'object',
-    properties: {
-      roomName: { type: 'string', description: 'Name of the room to delete' },
-    },
+    properties: { roomName: { type: 'string' } },
     required: ['roomName'],
   },
   execute: async (params: Record<string, unknown>) => {
@@ -76,14 +74,14 @@ export const createDeleteRoomTool = (removeRoom: RemoveRoomFn, house: House): To
 
 export const createSetRoomPromptTool = (house: House): Tool => ({
   name: 'set_room_prompt',
-  description: 'Sets or updates the system prompt for a room, which is injected into the context of all agents in that room.',
+  description: 'Set the system prompt for a room; injected into every agent in that room.',
   usage: 'Use to define or update the purpose and rules for a room. All agents in the room will receive this in their context.',
   returns: '{ roomName, prompt }.',
   parameters: {
     type: 'object',
     properties: {
-      roomName: { type: 'string', description: 'Name of the room to update' },
-      prompt: { type: 'string', description: 'The new room prompt text' },
+      roomName: { type: 'string' },
+      prompt: { type: 'string' },
     },
     required: ['roomName', 'prompt'],
   },
@@ -100,14 +98,14 @@ export const createSetRoomPromptTool = (house: House): Tool => ({
 
 export const createPauseRoomTool = (house: House): Tool => ({
   name: 'pause_room',
-  description: 'Pauses or unpauses message delivery in a room.',
+  description: 'Pause or unpause message delivery in a room.',
   usage: 'Use to pause a room temporarily while re-configuring it (adding agents, changing mode), then unpause when ready. Does not affect join/leave messages.',
   returns: '{ roomName, paused }.',
   parameters: {
     type: 'object',
     properties: {
-      roomName: { type: 'string', description: 'Name of the room' },
-      paused: { type: 'boolean', description: 'true to pause, false to unpause' },
+      roomName: { type: 'string' },
+      paused: { type: 'boolean' },
     },
     required: ['roomName', 'paused'],
   },
@@ -124,14 +122,12 @@ export const createPauseRoomTool = (house: House): Tool => ({
 
 export const createSetDeliveryModeTool = (house: House): Tool => ({
   name: 'set_delivery_mode',
-  description: 'Sets the delivery mode of a room to broadcast.',
+  description: 'Switch a room to broadcast delivery.',
   usage: 'Use to switch a room to broadcast mode so all members receive every message.',
   returns: '{ roomName, mode }.',
   parameters: {
     type: 'object',
-    properties: {
-      roomName: { type: 'string', description: 'Name of the room to update' },
-    },
+    properties: { roomName: { type: 'string' } },
     required: ['roomName'],
   },
   execute: async (params: Record<string, unknown>) => {
@@ -146,14 +142,14 @@ export const createSetDeliveryModeTool = (house: House): Tool => ({
 
 export const createAddToRoomTool = (team: Team, house: House, addAgentToRoom: AddToRoomFn): Tool => ({
   name: 'add_to_room',
-  description: 'Adds an agent (yourself or another) to a room.',
+  description: 'Add an agent (yourself or another) to a room. Use your own name to join.',
   usage: 'Use to join a room yourself or invite another agent. Triggers a visible join notification. Use your own name to join a room you are not yet in.',
   returns: 'Confirmation with the agent name and room name.',
   parameters: {
     type: 'object',
     properties: {
-      agentName: { type: 'string', description: 'Name of the agent to add (use own name to join)' },
-      roomName: { type: 'string', description: 'Name of the room to join' },
+      agentName: { type: 'string' },
+      roomName: { type: 'string' },
     },
     required: ['agentName', 'roomName'],
   },
@@ -173,14 +169,14 @@ export const createAddToRoomTool = (team: Team, house: House, addAgentToRoom: Ad
 
 export const createRemoveFromRoomTool = (team: Team, house: House, removeAgentFromRoom: RemoveFromRoomFn): Tool => ({
   name: 'remove_from_room',
-  description: 'Removes an agent (yourself or another) from a room.',
+  description: 'Remove an agent (yourself or another) from a room.',
   usage: 'Use to leave a room when your participation is complete, or to remove another agent. Triggers a visible leave notification. You can still re-join later.',
   returns: 'Confirmation with the agent name and room name.',
   parameters: {
     type: 'object',
     properties: {
-      agentName: { type: 'string', description: 'Name of the agent to remove (use own name to leave)' },
-      roomName: { type: 'string', description: 'Name of the room' },
+      agentName: { type: 'string' },
+      roomName: { type: 'string' },
     },
     required: ['agentName', 'roomName'],
   },

--- a/src/tools/built-in/utility-tools.ts
+++ b/src/tools/built-in/utility-tools.ts
@@ -4,7 +4,7 @@ import { resolveRoom } from './resolve.ts'
 
 export const createGetTimeTool = (): Tool => ({
   name: 'get_time',
-  description: 'Returns the current date and time in ISO 8601 format.',
+  description: 'Current ISO-8601 timestamp.',
   usage: 'Call when temporal accuracy matters. Do not guess.',
   returns: 'Object with a "time" field containing the ISO 8601 timestamp, e.g. { "time": "2024-01-15T12:30:00.000Z" }.',
   parameters: {},
@@ -16,14 +16,14 @@ export const createGetTimeTool = (): Tool => ({
 
 export const createPostToRoomTool = (house: House): Tool => ({
   name: 'post_to_room',
-  description: 'Posts a message to a specific room on behalf of the calling agent.',
+  description: 'Post a message to a specific room. For replies in the current room, just write your response.',
   usage: 'Send to a room other than the current one (e.g. reporting back to a coordinator). For normal replies, just write your response.',
   returns: '{ messageId, roomName }.',
   parameters: {
     type: 'object',
     properties: {
-      roomName: { type: 'string', description: 'Name of the room to post into' },
-      content: { type: 'string', description: 'The message content to post' },
+      roomName: { type: 'string' },
+      content: { type: 'string' },
     },
     required: ['roomName', 'content'],
   },
@@ -46,14 +46,14 @@ export const createPostToRoomTool = (house: House): Tool => ({
 
 export const createGetRoomHistoryTool = (house: House): Tool => ({
   name: 'get_room_history',
-  description: 'Returns recent messages from a room.',
+  description: 'Return recent messages from a room. Omit roomName for the current room.',
   usage: 'Catch up on a room or review past decisions. Omit roomName for current room.',
   returns: 'Array of { senderName, content, type, timestamp }.',
   parameters: {
     type: 'object',
     properties: {
-      roomName: { type: 'string', description: 'Name of the room (omit to use current room)' },
-      limit: { type: 'number', description: 'Number of recent messages to return (default 20, max 100)' },
+      roomName: { type: 'string' },
+      limit: { type: 'number', default: 20, maximum: 100 },
     },
     required: [],
   },

--- a/src/tools/built-in/web-tools.ts
+++ b/src/tools/built-in/web-tools.ts
@@ -95,15 +95,15 @@ interface SearchResult {
 
 const buildTavilySearchTool = (apiKey: string): Tool => ({
   name: 'web_search',
-  description: 'Searches the web (LLM-optimized via Tavily) and returns ranked results with cleaned content snippets and relevance scores.',
+  description: 'Web search via Tavily — ranked results with LLM-ready snippets. Only call web_fetch if a snippet is insufficient.',
   usage: 'Find current info or sources when you do not have a specific URL. Tavily snippets are LLM-ready; only call web_fetch if a snippet is insufficient.',
   returns: '{ query, provider, results: Array<{ title, url, snippet, score?, publishedAt? }> }. results may be empty if nothing is found.',
   parameters: {
     type: 'object',
     properties: {
-      query: { type: 'string', description: 'The search query' },
-      count: { type: 'number', description: 'Number of results to return (default 5, max 10)' },
-      depth: { type: 'string', description: 'Search depth: "basic" (1 credit, default) or "advanced" (2 credits, deeper crawl)' },
+      query: { type: 'string' },
+      count: { type: 'number', default: 5, minimum: 1, maximum: 10 },
+      depth: { type: 'string', enum: ['basic', 'advanced'], default: 'basic' },
     },
     required: ['query'],
   },
@@ -154,14 +154,14 @@ const buildTavilySearchTool = (apiKey: string): Tool => ({
 
 const buildBraveSearchTool = (apiKey: string): Tool => ({
   name: 'web_search',
-  description: 'Searches the web and returns a ranked list of results (title, URL, snippet) for a query.',
+  description: 'Web search (Brave). Returns snippets; call web_fetch for full content.',
   usage: 'Find pages when you do not have a URL. Returns snippets only — follow up with web_fetch for full content.',
   returns: '{ query, provider, results: Array<{ title, url, snippet, publishedAt? }> }. results may be empty if nothing is found.',
   parameters: {
     type: 'object',
     properties: {
-      query: { type: 'string', description: 'The search query' },
-      count: { type: 'number', description: 'Number of results to return (default 5, max 10)' },
+      query: { type: 'string' },
+      count: { type: 'number', default: 5, minimum: 1, maximum: 10 },
     },
     required: ['query'],
   },
@@ -201,14 +201,14 @@ const buildBraveSearchTool = (apiKey: string): Tool => ({
 
 const buildGoogleSearchTool = (apiKey: string, cseId: string): Tool => ({
   name: 'web_search',
-  description: 'Searches the web and returns a ranked list of results (title, URL, snippet) for a query.',
+  description: 'Web search (Google CSE). Returns snippets; call web_fetch for full content.',
   usage: 'Find pages when you do not have a URL. Returns snippets only — follow up with web_fetch for full content.',
   returns: '{ query, provider, results: Array<{ title, url, snippet }> }. results may be empty if nothing is found.',
   parameters: {
     type: 'object',
     properties: {
-      query: { type: 'string', description: 'The search query' },
-      count: { type: 'number', description: 'Number of results to return (default 5, max 10)' },
+      query: { type: 'string' },
+      count: { type: 'number', default: 5, minimum: 1, maximum: 10 },
     },
     required: ['query'],
   },
@@ -252,14 +252,14 @@ const tryCreateSearchTool = (config: WebToolsConfig): Tool | undefined => {
 
 export const webFetchTool: Tool = {
   name: 'web_fetch',
-  description: 'Fetches a URL and returns its content as clean Markdown text. Handles HTML pages, plain text, and JSON responses.',
+  description: 'Fetch a URL and return its content as clean Markdown. No JS execution; for JSON APIs prefer web_extract_json.',
   usage: 'Read a specific page. No JS execution — JS-rendered pages may be incomplete. For JSON APIs, use web_extract_json.',
   returns: '{ url, title, content, charCount, truncated }. content is cleaned Markdown text.',
   parameters: {
     type: 'object',
     properties: {
-      url: { type: 'string', description: 'Full URL to fetch (must use http or https)' },
-      maxChars: { type: 'number', description: 'Max characters of content to return (default: agent context budget, max 32000)' },
+      url: { type: 'string', description: 'http or https' },
+      maxChars: { type: 'number', maximum: 32000 },
     },
     required: ['url'],
   },
@@ -339,14 +339,14 @@ export const webFetchTool: Tool = {
 
 export const webExtractJsonTool: Tool = {
   name: 'web_extract_json',
-  description: 'Fetches a URL that returns JSON and extracts the data. Optionally navigate to a nested field using dot notation.',
+  description: 'Fetch a JSON endpoint and optionally navigate to a nested field by dot path (e.g. "results.0.title").',
   usage: 'For JSON endpoints (REST APIs, feeds). Prefer over web_fetch for application/json. Path uses dot notation: "results.0.title".',
   returns: '{ url, data, truncated } where data is the parsed JSON or the value at the given path.',
   parameters: {
     type: 'object',
     properties: {
-      url: { type: 'string', description: 'URL of the JSON API endpoint' },
-      path: { type: 'string', description: 'Dot-notation path to a nested value (e.g. "results.0.title"). Omit to return the whole response.' },
+      url: { type: 'string' },
+      path: { type: 'string', description: 'Dot path; omit for whole response.' },
     },
     required: ['url'],
   },

--- a/src/ui/modules/biometric/session-registry.test.ts
+++ b/src/ui/modules/biometric/session-registry.test.ts
@@ -1,12 +1,13 @@
-// Pure-TS unit tests for the session registry. No DOM, no MediaPipe, no
-// real getUserMedia — the registry is provider-agnostic (it accepts any
-// CaptureSession). We pass a real factory-function implementation of
-// CaptureSession that records stop() calls. Same "real interface with
-// controlled behavior" pattern as makeStubGateway in biometric-flow.test.ts;
-// not a mock.
+// Tests for the biometric specialisation of the generic wrapper-registry.
+// Acts as a contract test for that consumer — the generic surface itself
+// is covered in src/ui/modules/wrapper-registry/index.test.ts.
 //
-// The "wrapper" only needs an isConnected boolean for the sweeper. We
-// build a minimal object literal that satisfies that surface.
+// We pass a real factory-function CaptureSession (records stop() calls)
+// rather than a mock — per feedback_no_mocks.md.
+//
+// Registry entries expose fields under generic names (id, resource,
+// wrapper); biometric callers map them onto their domain at access time
+// (id ↔ captureId, resource ↔ session).
 
 import { describe, test, expect } from 'bun:test'
 import { createSessionRegistry, type ReleaseReason } from './session-registry.ts'
@@ -55,9 +56,9 @@ describe('session registry', () => {
     reg.attach('cap_1', session, wrapper)
     const entry = reg.get('cap_1')
     expect(entry).toBeTruthy()
-    expect(entry?.captureId).toBe('cap_1')
-    expect(entry?.session).toBe(session)
-    expect(entry?.attachedWrapper).toBe(wrapper)
+    expect(entry?.id).toBe('cap_1')
+    expect(entry?.resource).toBe(session)
+    expect(entry?.wrapper).toBe(wrapper)
   })
 
   test('get returns null for unknown captureId', () => {
@@ -105,7 +106,7 @@ describe('session registry', () => {
     const w2 = makeWrapper(true) as unknown as HTMLElement
     reg.attach('cap_1', session, w1)
     reg.setWrapper('cap_1', w2)
-    expect(reg.get('cap_1')?.attachedWrapper).toBe(w2)
+    expect(reg.get('cap_1')?.wrapper).toBe(w2)
     expect(session.stopCalls()).toBe(0)
   })
 

--- a/src/ui/modules/biometric/session-registry.ts
+++ b/src/ui/modules/biometric/session-registry.ts
@@ -1,65 +1,31 @@
-// Tab-scoped registry of live biometric capture sessions, keyed by
-// captureId. The MediaStream AND the widget's view-side timers are owned
-// here — outside the DOM widget — so re-renders, room switches, and any
-// other event that detaches the widget wrapper cannot orphan a camera OR
-// leave phantom signal-push timers ticking against a dead session.
+// Biometric session registry — thin specialisation of the generic
+// wrapper-registry over CaptureSession. The MediaStream AND the widget's
+// view-side timers are owned here, outside the DOM widget, so chat
+// re-renders cannot orphan a camera or leave phantom signal-push timers
+// ticking against a dead session.
 //
-// Lifecycle invariants:
-//   - attach() registers a freshly-started session with its wrapper.
-//   - setWrapper() swaps the attached wrapper on widget re-mount (the
-//     fenced block was re-parsed by markdown and a new wrapper element
-//     took the old one's place). The session keeps streaming; no
-//     re-consent, no second getUserMedia.
-//   - setViewBinding() stores a teardown callback alongside the session.
-//     Calling it again replaces (and tears down) the previous binding,
-//     so a re-mount that rewires fresh timers doesn't leak the old ones.
-//   - release() is the SOLE chokepoint that stops a session. It runs the
-//     view-binding's teardown FIRST (in its own try/catch so a thrown
-//     teardown can't prevent session.stop()), then stops the session,
-//     then fires the onRelease hook, then fans out to onAllReleased
-//     subscribers. Idempotent.
-//   - releaseAll() iterates and releases — replaces the three open-coded
-//     fan-out loops that previously walked _entries() from widget.ts.
-//   - sweepOrphans() releases any session whose wrapper has been detached.
-//     This is what makes the leak structurally impossible — no matter
-//     which mutation event fires (or doesn't), the next sweep tick stops
-//     the camera AND the view-side timers.
+// All lifecycle semantics (attach / setWrapper / setViewBinding / release /
+// releaseAll / sweepOrphans / onAllReleased) live in the generic module;
+// see src/ui/modules/wrapper-registry/index.ts for the invariants.
 //
-// The registry is tab-scoped. Cross-tab claim resolution still happens
-// over WS via biometric_capture_claimed broadcast.
+// The only biometric-specific behaviour here is:
+//   - disposeResource = (s) => s.stop() (swallow throws — release must complete)
+//   - re-export ReleaseReason under this module name so callers that
+//     thread `reason` through WS messages don't need to import the
+//     generic path
 
+import {
+  createWrapperRegistry,
+  type ReleaseReason,
+  type WrapperRegistry,
+} from '../wrapper-registry/index.ts'
 import type { CaptureSession } from '../../../biometrics/index.ts'
 
-export type ReleaseReason = 'user' | 'agent' | 'unmount' | 'disconnect' | 'error'
-
-export interface LiveSession {
-  readonly captureId: string
-  readonly session: CaptureSession
-  readonly attachedWrapper: HTMLElement | null
-}
-
-export interface ViewBinding {
-  readonly teardown: () => void
-}
-
-export interface SessionRegistry {
-  readonly get: (captureId: string) => LiveSession | null
-  readonly attach: (captureId: string, session: CaptureSession, wrapper: HTMLElement) => void
-  readonly setWrapper: (captureId: string, wrapper: HTMLElement) => void
-  readonly setViewBinding: (captureId: string, binding: ViewBinding) => void
-  readonly release: (captureId: string, reason: ReleaseReason) => Promise<void>
-  readonly releaseAll: (reason: ReleaseReason) => Promise<void>
-  readonly sweepOrphans: () => Promise<void>
-  // Multi-subscriber notification fired after each release completes.
-  // Returns an unsubscribe.
-  readonly onAllReleased: (cb: (captureId: string, reason: ReleaseReason) => void) => () => void
-}
-
-const SWEEP_INTERVAL_MS = 2000
+export type { ReleaseReason }
+export type SessionRegistry = WrapperRegistry<CaptureSession>
 
 export interface SessionRegistryConfig {
-  // Optional override for tests — when null, sweepOrphans() can still be
-  // driven manually. Production uses setInterval.
+  // Optional override for tests.
   readonly scheduler?: {
     readonly setInterval: (cb: () => void, ms: number) => unknown
     readonly clearInterval: (handle: unknown) => void
@@ -70,96 +36,10 @@ export interface SessionRegistryConfig {
   readonly onRelease?: (captureId: string, reason: ReleaseReason) => void
 }
 
-export const createSessionRegistry = (config: SessionRegistryConfig = {}): SessionRegistry => {
-  interface Entry {
-    session: CaptureSession
-    wrapper: HTMLElement | null
-    viewBinding: ViewBinding | null
-  }
-  const entries = new Map<string, Entry>()
-  const subscribers = new Set<(captureId: string, reason: ReleaseReason) => void>()
-  const scheduler = config.scheduler ?? {
-    setInterval: (cb, ms) => globalThis.setInterval(cb, ms),
-    clearInterval: (h) => globalThis.clearInterval(h as ReturnType<typeof setInterval>),
-  }
-  let sweepHandle: unknown = null
-
-  const ensureSweeper = (): void => {
-    if (sweepHandle !== null) return
-    sweepHandle = scheduler.setInterval(() => { void registry.sweepOrphans() }, SWEEP_INTERVAL_MS)
-  }
-  const stopSweeperIfEmpty = (): void => {
-    if (entries.size === 0 && sweepHandle !== null) {
-      scheduler.clearInterval(sweepHandle)
-      sweepHandle = null
-    }
-  }
-
-  const registry: SessionRegistry = {
-    get: (captureId) => {
-      const e = entries.get(captureId)
-      return e ? { captureId, session: e.session, attachedWrapper: e.wrapper } : null
-    },
-    attach: (captureId, session, wrapper) => {
-      entries.set(captureId, { session, wrapper, viewBinding: null })
-      ensureSweeper()
-      console.debug('[biometric:lifecycle] attach', { captureId })
-    },
-    setWrapper: (captureId, wrapper) => {
-      const e = entries.get(captureId)
-      if (!e) return
-      e.wrapper = wrapper
-      console.debug('[biometric:lifecycle] setWrapper', { captureId })
-    },
-    setViewBinding: (captureId, binding) => {
-      const e = entries.get(captureId)
-      if (!e) return
-      // Replace: tear down the previous binding's timers/listeners before
-      // overwriting. Re-mount paths rely on this to clean up the prior
-      // wrapper's intervals when the second wrapper rewires fresh ones.
-      if (e.viewBinding) {
-        try { e.viewBinding.teardown() } catch { /* ignore */ }
-      }
-      e.viewBinding = binding
-    },
-    release: async (captureId, reason) => {
-      const e = entries.get(captureId)
-      if (!e) return
-      entries.delete(captureId)
-      console.debug('[biometric:lifecycle] release', { captureId, reason })
-      // Order matters: view-binding teardown FIRST (independent try/catch
-      // so a thrown teardown can't skip session.stop), THEN session.stop,
-      // THEN the config hook + subscribers.
-      try { e.viewBinding?.teardown() } catch { /* ignore */ }
-      try { await e.session.stop() } catch { /* always swallow — release must complete */ }
-      try { config.onRelease?.(captureId, reason) } catch { /* ignore */ }
-      for (const cb of subscribers) {
-        try { cb(captureId, reason) } catch { /* ignore — one subscriber's bug can't break others */ }
-      }
-      stopSweeperIfEmpty()
-    },
-    releaseAll: async (reason) => {
-      // Snapshot ids before iterating so release() mutating the map is safe.
-      const ids = [...entries.keys()]
-      for (const id of ids) {
-        await registry.release(id, reason)
-      }
-    },
-    sweepOrphans: async () => {
-      const orphans: string[] = []
-      for (const [id, e] of entries) {
-        if (e.wrapper && !e.wrapper.isConnected) orphans.push(id)
-      }
-      for (const id of orphans) {
-        console.debug('[biometric:lifecycle] sweep released', { captureId: id, reason: 'unmount' })
-        await registry.release(id, 'unmount')
-      }
-    },
-    onAllReleased: (cb) => {
-      subscribers.add(cb)
-      return () => subscribers.delete(cb)
-    },
-  }
-
-  return registry
-}
+export const createSessionRegistry = (config: SessionRegistryConfig = {}): SessionRegistry =>
+  createWrapperRegistry<CaptureSession>({
+    label: 'biometric',
+    disposeResource: async (s) => { try { await s.stop() } catch { /* always swallow — release must complete */ } },
+    ...(config.scheduler ? { scheduler: config.scheduler } : {}),
+    ...(config.onRelease ? { onRelease: config.onRelease } : {}),
+  })

--- a/src/ui/modules/biometric/widget.ts
+++ b/src/ui/modules/biometric/widget.ts
@@ -245,8 +245,8 @@ const mountWidget = (wrapper: HTMLElement, payload: FencedPayload): void => {
     // old wrapper's intervals.
     sessionRegistry.setWrapper(payload.captureId, wrapper)
     const ui = renderActive(wrapper, payload)
-    void existing.session.retarget(ui.videoEl, ui.canvasEl)
-    const binding = wireActiveViewWithUI(wrapper, payload, existing.session, performance.now(), ui)
+    void existing.resource.retarget(ui.videoEl, ui.canvasEl)
+    const binding = wireActiveViewWithUI(wrapper, payload, existing.resource, performance.now(), ui)
     sessionRegistry.setViewBinding(payload.captureId, binding)
     return
   }

--- a/src/ui/modules/map/index.ts
+++ b/src/ui/modules/map/index.ts
@@ -14,6 +14,7 @@ import { parseMapSource, collectLatLngs, type ParsedMap, type EnvelopeFeature } 
 import { showMapFallback } from './fallback.ts'
 import { buildIconSpec } from './icons.ts'
 import { addPostRenderProcessor } from '../extensions/post-render-registry.ts'
+import { mapRegistry, nextMapId } from './map-registry.ts'
 
 const OSM_TILE_URL = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
 const OSM_ATTRIBUTION = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
@@ -158,7 +159,13 @@ const renderInto = async (container: HTMLElement, source: string): Promise<void>
     return
   }
 
-  buildMap(L, container, parsed, source)
+  const result = buildMap(L, container, parsed, source)
+  // Register for lifecycle ownership — sweep + release guarantee map.remove()
+  // runs when the wrapper detaches. Both call sites (chat-fence and the
+  // geodata-panel preview) route through here, so one attach() covers both.
+  if (result) {
+    mapRegistry.attach(nextMapId(), result.map, container)
+  }
 }
 
 export const renderMapBlocks = async (container: HTMLElement): Promise<void> => {

--- a/src/ui/modules/map/map-registry.test.ts
+++ b/src/ui/modules/map/map-registry.test.ts
@@ -1,0 +1,128 @@
+// Tests for the map-registry specialisation. Verifies the leak fix:
+// detached wrappers result in map.remove() calls via the generic sweep.
+// Uses a fake LeafletMap (counter object) — no real Leaflet, no DOM
+// beyond a minimal FakeWrapper with isConnected.
+
+import { describe, test, expect } from 'bun:test'
+import { createWrapperRegistry, type WrapperRegistry } from '../wrapper-registry/index.ts'
+import type { LeafletMap } from './api.ts'
+import { nextMapId } from './map-registry.ts'
+
+interface FakeWrapper { isConnected: boolean }
+const makeWrapper = (isConnected = true): FakeWrapper => ({ isConnected })
+
+interface FakeMap {
+  removeCalls: number
+  remove: () => void
+}
+const makeMap = (behaviour: 'ok' | 'throws-second' = 'ok'): FakeMap => {
+  const m: FakeMap = {
+    removeCalls: 0,
+    remove() {
+      m.removeCalls += 1
+      // Models Leaflet's non-idempotent Map.remove() — second call throws.
+      if (behaviour === 'throws-second' && m.removeCalls > 1) {
+        throw new Error('Map.remove() called twice')
+      }
+    },
+  }
+  return m
+}
+
+// Helper: build a test-scoped registry that mirrors mapRegistry's config
+// but with an injected manual scheduler so tests can drive sweep ticks.
+const makeTestMapRegistry = (): { reg: WrapperRegistry<LeafletMap>; tick: () => void } => {
+  const callbacks: Array<() => void> = []
+  const scheduler = {
+    setInterval: (cb: () => void) => { callbacks.push(cb); return callbacks.length - 1 },
+    clearInterval: (_h: unknown) => { /* no-op */ },
+  }
+  const reg = createWrapperRegistry<LeafletMap>({
+    label: 'map-test',
+    scheduler,
+    disposeResource: async (m) => { try { m.remove() } catch { /* tolerate double-dispose */ } },
+  })
+  return { reg, tick: () => { for (const cb of callbacks) cb() } }
+}
+
+describe('map-registry: leak fix', () => {
+  test('detached wrapper → sweep calls map.remove() exactly once', async () => {
+    const { reg, tick } = makeTestMapRegistry()
+    const m = makeMap()
+    const w = makeWrapper(true) as unknown as HTMLElement
+    reg.attach('map-1', m as unknown as LeafletMap, w)
+
+    ;(w as unknown as FakeWrapper).isConnected = false
+    tick()
+    await new Promise<void>(resolve => setTimeout(resolve, 0))
+
+    expect(m.removeCalls).toBe(1)
+    expect(reg.get('map-1')).toBeNull()
+  })
+
+  test('two distinct maps → both removed on a single sweep', async () => {
+    const { reg, tick } = makeTestMapRegistry()
+    const m1 = makeMap(), m2 = makeMap()
+    const w1 = makeWrapper(true) as unknown as HTMLElement
+    const w2 = makeWrapper(true) as unknown as HTMLElement
+    reg.attach('map-1', m1 as unknown as LeafletMap, w1)
+    reg.attach('map-2', m2 as unknown as LeafletMap, w2)
+
+    ;(w1 as unknown as FakeWrapper).isConnected = false
+    ;(w2 as unknown as FakeWrapper).isConnected = false
+    tick()
+    await new Promise<void>(resolve => setTimeout(resolve, 0))
+
+    expect(m1.removeCalls).toBe(1)
+    expect(m2.removeCalls).toBe(1)
+  })
+
+  test('releaseAll("disconnect") removes every map', async () => {
+    const { reg } = makeTestMapRegistry()
+    const m1 = makeMap(), m2 = makeMap()
+    const w = makeWrapper(true) as unknown as HTMLElement
+    reg.attach('map-1', m1 as unknown as LeafletMap, w)
+    reg.attach('map-2', m2 as unknown as LeafletMap, w)
+
+    await reg.releaseAll('disconnect')
+    expect(m1.removeCalls).toBe(1)
+    expect(m2.removeCalls).toBe(1)
+  })
+
+  test('Leaflet-style non-idempotent remove() — sweep + release race tolerated', async () => {
+    // Models the real Leaflet contract: second remove() throws. The
+    // registry's get-then-delete in release() guarantees disposeResource
+    // runs at most once per id, but the dispose itself swallows the
+    // throw so a concurrent release wins gracefully.
+    const { reg, tick } = makeTestMapRegistry()
+    const m = makeMap('throws-second')
+    const w = makeWrapper(true) as unknown as HTMLElement
+    reg.attach('map-1', m as unknown as LeafletMap, w)
+
+    ;(w as unknown as FakeWrapper).isConnected = false
+    // Fire sweep + explicit release concurrently — neither should reject.
+    const sweepP = (async () => { tick(); await new Promise<void>(resolve => setTimeout(resolve, 0)) })()
+    const relP = reg.release('map-1', 'user')
+    await Promise.all([sweepP, relP])
+
+    // Disposed at most once (the registry's get-then-delete is the guard).
+    expect(m.removeCalls).toBe(1)
+  })
+})
+
+describe('map-registry: id allocation', () => {
+  test('nextMapId() returns distinct ids on each call across the module', () => {
+    // Module-scope counter regression test (Finding 1.5): per-call
+    // counters could overlap and silently overwrite registry entries.
+    const a = nextMapId()
+    const b = nextMapId()
+    const c = nextMapId()
+    expect(a).not.toBe(b)
+    expect(b).not.toBe(c)
+    expect(a).not.toBe(c)
+  })
+
+  test('nextMapId() prefix is stable', () => {
+    expect(nextMapId().startsWith('map-')).toBe(true)
+  })
+})

--- a/src/ui/modules/map/map-registry.ts
+++ b/src/ui/modules/map/map-registry.ts
@@ -1,0 +1,46 @@
+// Map registry — owns LeafletMap instances outside the DOM wrapper that
+// holds them, closing a real leak: previous code created `L.map(container)`
+// and never called `.remove()`. When the chat re-rendered a message or the
+// geodata panel was closed/reopened, the Leaflet instance kept its DOM
+// listeners, tile-load callbacks, and internal references alive — slow
+// growth in the hundreds of KB per dropped map.
+//
+// This is a thin specialisation of src/ui/modules/wrapper-registry/index.ts.
+// Lifecycle semantics live there; this module supplies only:
+//   - the LeafletMap-specific disposal (map.remove())
+//   - a module-scope id counter (nextMapId) — per-call counters could
+//     produce overlapping ids that collide in entries.set() across
+//     re-renders, silently dropping a map's resource without disposing.
+//
+// Worst-case bound: sweep runs every 2000 ms (same as biometrics, so
+// timing is consistent across registries). A chat re-render that detaches
+// N map wrappers between ticks holds up to N Leaflet instances (~100 KB
+// each) until the next tick. Acceptable: bound is small in practice, and
+// a tighter sweep would burn CPU on idle pages.
+//
+// No releaseAll wiring on page-unload (unlike biometrics): the biometric
+// listeners exist to release a real OS resource (the camera). Leaflet
+// instances are pure in-page state; browser GC handles them on a real
+// page unload. The registry's only job here is in-page detach cases.
+//
+// Two sweep timers run when both biometric + map registries are active.
+// Trivial cost; documented for symmetry with biometric/session-registry.ts.
+
+import { createWrapperRegistry, type WrapperRegistry } from '../wrapper-registry/index.ts'
+import type { LeafletMap } from './api.ts'
+
+// Module-scope counter — see Finding 1.5 in the wrapper-registry stress-test.
+let mapIdCounter = 0
+export const nextMapId = (): string => `map-${++mapIdCounter}`
+
+export type MapRegistry = WrapperRegistry<LeafletMap>
+
+export const mapRegistry: MapRegistry = createWrapperRegistry<LeafletMap>({
+  label: 'map',
+  // Leaflet's Map.remove() is NOT idempotent — calling it twice throws.
+  // The registry's get-then-delete ensures release() runs at most once
+  // per id, but sweep and an explicit release could still race
+  // (sweep ticks while a Stop handler is in flight). Swallow inside
+  // dispose so the race is harmless.
+  disposeResource: async (m) => { try { m.remove() } catch { /* tolerate double-dispose */ } },
+})

--- a/src/ui/modules/wrapper-registry/index.test.ts
+++ b/src/ui/modules/wrapper-registry/index.test.ts
@@ -1,0 +1,272 @@
+// Tests for the generic wrapper-registry. Real fake resources implementing
+// a minimal contract — no mocks. The biometric specialisation
+// (session-registry.test.ts) acts as the contract test for one concrete
+// consumer; this file tests the generic surface in isolation.
+
+import { describe, test, expect } from 'bun:test'
+import { createWrapperRegistry, type ReleaseReason } from './index.ts'
+
+interface FakeWrapper { isConnected: boolean }
+const makeWrapper = (isConnected = true): FakeWrapper => ({ isConnected })
+
+interface FakeResource {
+  readonly id: string
+  readonly disposeCalls: () => number
+}
+
+const makeResource = (id: string, behaviour: 'ok' | 'throws' = 'ok'): FakeResource & { __disposed: number } => {
+  const r = { id, __disposed: 0 }
+  return Object.assign(r, {
+    disposeCalls: () => r.__disposed,
+    __throws: behaviour === 'throws',
+  })
+}
+
+const makeRegistry = (overrides: { throws?: boolean; sweepMs?: number } = {}) => {
+  const callbacks: Array<() => void> = []
+  const scheduler = {
+    setInterval: (cb: () => void) => { callbacks.push(cb); return callbacks.length - 1 },
+    clearInterval: (_h: unknown) => { /* no-op for tests */ },
+  }
+  const reg = createWrapperRegistry<ReturnType<typeof makeResource>>({
+    label: 'test',
+    scheduler,
+    ...(overrides.sweepMs !== undefined ? { sweepIntervalMs: overrides.sweepMs } : {}),
+    disposeResource: async (r) => {
+      r.__disposed += 1
+      if (overrides.throws) throw new Error('dispose blew up')
+    },
+  })
+  return { reg, tick: () => { for (const cb of callbacks) cb() }, timerCount: () => callbacks.length }
+}
+
+describe('wrapper-registry: basic lifecycle', () => {
+  test('attach then get returns the entry with generic field names', () => {
+    const { reg } = makeRegistry()
+    const r = makeResource('cap_1')
+    const w = makeWrapper(true) as unknown as HTMLElement
+    reg.attach('cap_1', r, w)
+    const e = reg.get('cap_1')
+    expect(e).toBeTruthy()
+    expect(e?.id).toBe('cap_1')
+    expect(e?.resource).toBe(r)
+    expect(e?.wrapper).toBe(w)
+  })
+
+  test('get returns null for unknown id', () => {
+    const { reg } = makeRegistry()
+    expect(reg.get('nope')).toBeNull()
+  })
+
+  test('release disposes the resource and removes the entry', async () => {
+    const { reg } = makeRegistry()
+    const r = makeResource('cap_1')
+    const w = makeWrapper(true) as unknown as HTMLElement
+    reg.attach('cap_1', r, w)
+    await reg.release('cap_1', 'user')
+    expect(r.disposeCalls()).toBe(1)
+    expect(reg.get('cap_1')).toBeNull()
+  })
+
+  test('release is idempotent — second call is a no-op', async () => {
+    const { reg } = makeRegistry()
+    const r = makeResource('cap_1')
+    reg.attach('cap_1', r, makeWrapper(true) as unknown as HTMLElement)
+    await reg.release('cap_1', 'user')
+    await reg.release('cap_1', 'agent')
+    expect(r.disposeCalls()).toBe(1)
+  })
+
+  test('disposeResource throwing does not stall release', async () => {
+    const { reg } = makeRegistry({ throws: true })
+    const r = makeResource('cap_1')
+    reg.attach('cap_1', r, makeWrapper(true) as unknown as HTMLElement)
+    await reg.release('cap_1', 'user')   // must not reject
+    expect(reg.get('cap_1')).toBeNull()
+  })
+
+  test('tolerates double-dispose: sweep + release race lands at most one dispose-with-side-effect', async () => {
+    // Models Leaflet's non-idempotent map.remove(): the registry calls
+    // disposeResource at most once because release() deletes the entry
+    // before disposing. A second release on the same id is a no-op
+    // (handled by get-then-delete check, not by the underlying resource).
+    const { reg } = makeRegistry()
+    const r = makeResource('cap_1')
+    reg.attach('cap_1', r, makeWrapper(true) as unknown as HTMLElement)
+    await Promise.all([reg.release('cap_1', 'user'), reg.release('cap_1', 'agent')])
+    expect(r.disposeCalls()).toBe(1)
+  })
+})
+
+describe('wrapper-registry: onRelease + onAllReleased', () => {
+  test('onRelease hook fires with id and reason', async () => {
+    const calls: Array<{ id: string; reason: ReleaseReason }> = []
+    const callbacks: Array<() => void> = []
+    const reg = createWrapperRegistry<ReturnType<typeof makeResource>>({
+      label: 'test',
+      scheduler: { setInterval: (cb) => { callbacks.push(cb); return 0 }, clearInterval: () => {} },
+      disposeResource: async () => {},
+      onRelease: (id, reason) => calls.push({ id, reason }),
+    })
+    reg.attach('cap_1', makeResource('cap_1'), makeWrapper(true) as unknown as HTMLElement)
+    await reg.release('cap_1', 'unmount')
+    expect(calls).toEqual([{ id: 'cap_1', reason: 'unmount' }])
+  })
+
+  test('onAllReleased subscribers fire after release; unsubscribe stops them', async () => {
+    const { reg } = makeRegistry()
+    const calls: string[] = []
+    const unsub = reg.onAllReleased((id) => calls.push(id))
+
+    reg.attach('cap_1', makeResource('cap_1'), makeWrapper(true) as unknown as HTMLElement)
+    await reg.release('cap_1', 'user')
+    expect(calls).toEqual(['cap_1'])
+
+    unsub()
+    reg.attach('cap_2', makeResource('cap_2'), makeWrapper(true) as unknown as HTMLElement)
+    await reg.release('cap_2', 'user')
+    expect(calls).toEqual(['cap_1'])
+  })
+
+  test('subscriber throwing does not break other subscribers or release', async () => {
+    const { reg } = makeRegistry()
+    const calls: string[] = []
+    reg.onAllReleased(() => { throw new Error('boom') })
+    reg.onAllReleased((id) => calls.push(id))
+    reg.attach('cap_1', makeResource('cap_1'), makeWrapper(true) as unknown as HTMLElement)
+    await reg.release('cap_1', 'user')
+    expect(calls).toEqual(['cap_1'])
+  })
+})
+
+describe('wrapper-registry: view bindings', () => {
+  test('setViewBinding teardown runs once on release, BEFORE dispose', async () => {
+    const order: string[] = []
+    const callbacks: Array<() => void> = []
+    const reg = createWrapperRegistry<{ id: string }>({
+      label: 'test',
+      scheduler: { setInterval: (cb) => { callbacks.push(cb); return 0 }, clearInterval: () => {} },
+      disposeResource: async () => { order.push('dispose') },
+    })
+    reg.attach('cap_1', { id: 'cap_1' }, makeWrapper(true) as unknown as HTMLElement)
+    reg.setViewBinding('cap_1', { teardown: () => { order.push('teardown') } })
+    await reg.release('cap_1', 'user')
+    expect(order).toEqual(['teardown', 'dispose'])
+  })
+
+  test('setViewBinding called twice tears down the previous binding', () => {
+    const { reg } = makeRegistry()
+    reg.attach('cap_1', makeResource('cap_1'), makeWrapper(true) as unknown as HTMLElement)
+    let downA = 0, downB = 0
+    reg.setViewBinding('cap_1', { teardown: () => { downA += 1 } })
+    reg.setViewBinding('cap_1', { teardown: () => { downB += 1 } })
+    expect(downA).toBe(1)
+    expect(downB).toBe(0)
+  })
+
+  test('thrown view-binding teardown does not skip dispose', async () => {
+    const { reg } = makeRegistry()
+    const r = makeResource('cap_1')
+    reg.attach('cap_1', r, makeWrapper(true) as unknown as HTMLElement)
+    reg.setViewBinding('cap_1', { teardown: () => { throw new Error('boom') } })
+    await reg.release('cap_1', 'user')
+    expect(r.disposeCalls()).toBe(1)
+  })
+
+  test('setViewBinding on unknown id is a no-op', () => {
+    const { reg } = makeRegistry()
+    expect(() => reg.setViewBinding('nope', { teardown: () => {} })).not.toThrow()
+  })
+})
+
+describe('wrapper-registry: setWrapper + sweepOrphans', () => {
+  test('setWrapper swaps the attached wrapper without disturbing the resource', () => {
+    const { reg } = makeRegistry()
+    const r = makeResource('cap_1')
+    const w1 = makeWrapper(true) as unknown as HTMLElement
+    const w2 = makeWrapper(true) as unknown as HTMLElement
+    reg.attach('cap_1', r, w1)
+    reg.setWrapper('cap_1', w2)
+    expect(reg.get('cap_1')?.wrapper).toBe(w2)
+    expect(r.disposeCalls()).toBe(0)
+  })
+
+  test('setWrapper on unknown id is a no-op', () => {
+    const { reg } = makeRegistry()
+    expect(() => reg.setWrapper('nope', makeWrapper(true) as unknown as HTMLElement)).not.toThrow()
+  })
+
+  test('sweepOrphans releases entries whose wrapper has been detached', async () => {
+    const { reg } = makeRegistry()
+    const live = makeResource('live')
+    const orphan = makeResource('orphan')
+    const liveW = makeWrapper(true) as unknown as HTMLElement
+    const orphanW = makeWrapper(true) as unknown as HTMLElement
+    reg.attach('live', live, liveW)
+    reg.attach('orphan', orphan, orphanW)
+
+    ;(orphanW as unknown as FakeWrapper).isConnected = false
+    await reg.sweepOrphans()
+
+    expect(live.disposeCalls()).toBe(0)
+    expect(orphan.disposeCalls()).toBe(1)
+    expect(reg.get('live')).toBeTruthy()
+    expect(reg.get('orphan')).toBeNull()
+  })
+
+  test('sweepOrphans fires view-binding teardown for the orphaned entry', async () => {
+    const { reg } = makeRegistry()
+    const r = makeResource('cap_1')
+    const w = makeWrapper(true) as unknown as HTMLElement
+    reg.attach('cap_1', r, w)
+    let torn = 0
+    reg.setViewBinding('cap_1', { teardown: () => { torn += 1 } })
+
+    ;(w as unknown as FakeWrapper).isConnected = false
+    await reg.sweepOrphans()
+
+    expect(torn).toBe(1)
+    expect(r.disposeCalls()).toBe(1)
+    expect(reg.get('cap_1')).toBeNull()
+  })
+
+  test('sweep timer fires via injected scheduler and stops when registry empties', async () => {
+    const { reg, tick, timerCount } = makeRegistry()
+    const r = makeResource('cap_1')
+    const w = makeWrapper(true) as unknown as HTMLElement
+    expect(timerCount()).toBe(0)
+    reg.attach('cap_1', r, w)
+    expect(timerCount()).toBe(1)
+
+    ;(w as unknown as FakeWrapper).isConnected = false
+    tick()
+    await new Promise<void>(resolve => setTimeout(resolve, 0))
+    expect(r.disposeCalls()).toBe(1)
+    expect(reg.get('cap_1')).toBeNull()
+  })
+})
+
+describe('wrapper-registry: releaseAll', () => {
+  test('releaseAll releases every entry with the given reason', async () => {
+    const { reg } = makeRegistry()
+    const a = makeResource('a'), b = makeResource('b'), c = makeResource('c')
+    const w = makeWrapper(true) as unknown as HTMLElement
+    reg.attach('a', a, w); reg.attach('b', b, w); reg.attach('c', c, w)
+    const reasons: ReleaseReason[] = []
+    reg.onAllReleased((_id, r) => reasons.push(r))
+
+    await reg.releaseAll('disconnect')
+    expect(a.disposeCalls()).toBe(1)
+    expect(b.disposeCalls()).toBe(1)
+    expect(c.disposeCalls()).toBe(1)
+    expect(reasons).toEqual(['disconnect', 'disconnect', 'disconnect'])
+    expect(reg.get('a')).toBeNull()
+  })
+
+  test('releaseAll on empty registry resolves cleanly', async () => {
+    const { reg } = makeRegistry()
+    await reg.releaseAll('disconnect')
+    // No assertion needed — just must not reject.
+    expect(true).toBe(true)
+  })
+})

--- a/src/ui/modules/wrapper-registry/index.ts
+++ b/src/ui/modules/wrapper-registry/index.ts
@@ -1,0 +1,180 @@
+// Generic wrapper-registry — owns a long-lived resource (T) outside the DOM
+// wrapper that displays it. Two consumers today:
+//
+//   biometrics (createSessionRegistry) — T = CaptureSession
+//   map        (mapRegistry)           — T = LeafletMap
+//
+// Why outside the DOM wrapper: chat re-renders detach wrappers without
+// warning. A camera left attached to a detached <video> keeps the MediaStream
+// alive (orphaned camera light). A Leaflet map left attached to a detached
+// container keeps its DOM listeners + tile callbacks + internal refs alive
+// (slow growth, hundreds of KB per dropped map). Owning the resource here
+// means we can sweep on a timer: any entry whose wrapper is no longer in
+// the document gets disposed.
+//
+// Lifecycle invariants:
+//   - attach(id, resource, wrapper) — fresh registration. starts the sweep
+//     timer (lazy) on first attach.
+//   - setWrapper(id, wrapper) — wrapper swap on re-mount; resource keeps
+//     running. Used by biometrics when markdown re-renders a fenced block.
+//   - setViewBinding(id, {teardown}) — optional. View-side teardown (e.g.
+//     timers, listeners) the registry runs BEFORE disposeResource on
+//     release. Replacing the binding tears down the previous one first.
+//     Biometrics uses this; map ignores it (uniform surface beats divergent
+//     APIs — Finding 3.5 from the stress-test).
+//   - release(id, reason) — SOLE chokepoint that disposes a resource.
+//     Ordering: viewBinding.teardown (try/swallow) → disposeResource
+//     (try/swallow) → onRelease config hook → onAllReleased subscribers.
+//     Independent try-blocks so a thrown teardown can't skip disposal.
+//   - releaseAll(reason) — release every entry; replaces open-coded
+//     fan-out loops in callers.
+//   - sweepOrphans() — release any entry whose wrapper is no longer in
+//     the document. The unconditional safety net: regardless of which
+//     mutation event fires (or doesn't), the next sweep tick cleans up.
+//
+// Two sweep timers run when both biometric + map registries are active.
+// Trivial cost; mentioned so a future reader doesn't think it's a bug.
+
+export type ReleaseReason = 'user' | 'agent' | 'unmount' | 'disconnect' | 'error'
+
+export interface ViewBinding {
+  readonly teardown: () => void
+}
+
+export interface RegistryEntry<T> {
+  readonly id: string
+  readonly resource: T
+  readonly wrapper: HTMLElement | null
+}
+
+export interface WrapperRegistry<T> {
+  readonly get: (id: string) => RegistryEntry<T> | null
+  readonly attach: (id: string, resource: T, wrapper: HTMLElement) => void
+  readonly setWrapper: (id: string, wrapper: HTMLElement) => void
+  readonly setViewBinding: (id: string, binding: ViewBinding) => void
+  readonly release: (id: string, reason: ReleaseReason) => Promise<void>
+  readonly releaseAll: (reason: ReleaseReason) => Promise<void>
+  readonly sweepOrphans: () => Promise<void>
+  readonly onAllReleased: (cb: (id: string, reason: ReleaseReason) => void) => () => void
+}
+
+export interface WrapperRegistryConfig<T> {
+  // Per-subsystem teardown of the resource itself. Forced async (one
+  // contract). disposeResource must tolerate being called when the
+  // resource is in any state — including already-disposed — because
+  // sweep and explicit release can race. Swallow throws inside the
+  // implementation rather than relying on the registry's try/catch
+  // for cleanliness; the registry's swallow is the last-line guarantee.
+  readonly disposeResource: (resource: T) => Promise<void>
+
+  // Optional per-release side effect (e.g. send a WS message).
+  // Runs AFTER disposeResource, BEFORE onAllReleased subscribers.
+  readonly onRelease?: (id: string, reason: ReleaseReason) => void
+
+  // Test seam — production uses globalThis.setInterval.
+  readonly scheduler?: {
+    readonly setInterval: (cb: () => void, ms: number) => unknown
+    readonly clearInterval: (handle: unknown) => void
+  }
+
+  // Default 2000. Tighter intervals burn CPU on idle pages.
+  readonly sweepIntervalMs?: number
+
+  // Debug label for console traces ('biometric', 'map', ...).
+  readonly label?: string
+}
+
+const DEFAULT_SWEEP_INTERVAL_MS = 2000
+
+export const createWrapperRegistry = <T>(config: WrapperRegistryConfig<T>): WrapperRegistry<T> => {
+  interface Entry {
+    resource: T
+    wrapper: HTMLElement | null
+    viewBinding: ViewBinding | null
+  }
+  const entries = new Map<string, Entry>()
+  const subscribers = new Set<(id: string, reason: ReleaseReason) => void>()
+  const scheduler = config.scheduler ?? {
+    setInterval: (cb, ms) => globalThis.setInterval(cb, ms),
+    clearInterval: (h) => globalThis.clearInterval(h as ReturnType<typeof setInterval>),
+  }
+  const sweepIntervalMs = config.sweepIntervalMs ?? DEFAULT_SWEEP_INTERVAL_MS
+  const label = config.label ?? 'wrapper'
+  let sweepHandle: unknown = null
+
+  const ensureSweeper = (): void => {
+    if (sweepHandle !== null) return
+    sweepHandle = scheduler.setInterval(() => { void registry.sweepOrphans() }, sweepIntervalMs)
+  }
+  const stopSweeperIfEmpty = (): void => {
+    if (entries.size === 0 && sweepHandle !== null) {
+      scheduler.clearInterval(sweepHandle)
+      sweepHandle = null
+    }
+  }
+
+  const registry: WrapperRegistry<T> = {
+    get: (id) => {
+      const e = entries.get(id)
+      return e ? { id, resource: e.resource, wrapper: e.wrapper } : null
+    },
+    attach: (id, resource, wrapper) => {
+      entries.set(id, { resource, wrapper, viewBinding: null })
+      ensureSweeper()
+      console.debug(`[${label}:lifecycle] attach`, { id })
+    },
+    setWrapper: (id, wrapper) => {
+      const e = entries.get(id)
+      if (!e) return
+      e.wrapper = wrapper
+      console.debug(`[${label}:lifecycle] setWrapper`, { id })
+    },
+    setViewBinding: (id, binding) => {
+      const e = entries.get(id)
+      if (!e) return
+      // Replace: tear down the previous binding first so a re-mount that
+      // rewires fresh timers doesn't leak the old ones.
+      if (e.viewBinding) {
+        try { e.viewBinding.teardown() } catch { /* ignore */ }
+      }
+      e.viewBinding = binding
+    },
+    release: async (id, reason) => {
+      const e = entries.get(id)
+      if (!e) return
+      entries.delete(id)
+      console.debug(`[${label}:lifecycle] release`, { id, reason })
+      // Independent try-blocks so a thrown teardown can't skip disposal.
+      try { e.viewBinding?.teardown() } catch { /* ignore */ }
+      try { await config.disposeResource(e.resource) } catch { /* always swallow — release must complete */ }
+      try { config.onRelease?.(id, reason) } catch { /* ignore */ }
+      for (const cb of subscribers) {
+        try { cb(id, reason) } catch { /* ignore — one subscriber's bug can't break others */ }
+      }
+      stopSweeperIfEmpty()
+    },
+    releaseAll: async (reason) => {
+      // Snapshot ids before iterating so release() mutating the map is safe.
+      const ids = [...entries.keys()]
+      for (const id of ids) {
+        await registry.release(id, reason)
+      }
+    },
+    sweepOrphans: async () => {
+      const orphans: string[] = []
+      for (const [id, e] of entries) {
+        if (e.wrapper && !e.wrapper.isConnected) orphans.push(id)
+      }
+      for (const id of orphans) {
+        console.debug(`[${label}:lifecycle] sweep released`, { id, reason: 'unmount' })
+        await registry.release(id, 'unmount')
+      }
+    },
+    onAllReleased: (cb) => {
+      subscribers.add(cb)
+      return () => subscribers.delete(cb)
+    },
+  }
+
+  return registry
+}


### PR DESCRIPTION
## Summary

Audit-driven reduction of the built-in tool token cost from **4304 → 2159 tok (-49.8%)**. Two commits.

**C1 — Structural** ([b23df88](../../commit/b23df88))
[tool-capability.ts](src/llm/tool-capability.ts) no longer appends `tool.usage` and `tool.returns` to the LLM-facing description. Those fields stay on the Tool type and still render in the [tool-detail modal](src/ui/modules/modals/tool-detail-modal.ts:69) for humans. The audit showed the prose mostly duplicated information the model gets from the first tool result anyway. This single change saves ~33% with zero behavioural rewrite required. Pack-bundled / external tools keep working — their `usage`/`returns` just stop going to the LLM.

**C2 — Style tightening** ([de86270](../../commit/de86270))
Rewrote built-in tool descriptions per the new contract codified in `tool-capability.ts`'s header:
- Single imperative clause; second sentence only for non-obvious constraint or cross-tool dependency
- Drop self-evident per-parameter descriptions ("Name of the room", "The query")
- Use JSON Schema fields (`default`, `enum`, `minimum`, `maximum`, `pattern`) instead of prose
- Fold contract-bearing `returns` sentences into `description` proper (geo_lookup, geo_list_features need the `data.renderable` fence-paste contract front-and-center)

**No budget test added.** A prior runtime token cap (deleted in `de6c0d1`) silently dropped pack tools when registration order changed. A CI budget test has the same shape of failure mode — creates friction against every legitimate new tool without catching the real risk (LLM-correctness regression, which a token count can't detect). LLM correctness is verified post-deploy via `/api/diagnostics/evals/recent` outcome-rate comparison, not a unit test.

**Cache-prefix benefit:** smaller tool surface improves prompt-cache utilisation on Anthropic / OpenAI, reduces cache eviction risk. Comparable to the family-compression win at the architecture level.

[docs/tools.md](docs/tools.md) updated with the new authoring contract for external/pack tool authors.

## Test plan

- [x] `bun run check` clean
- [x] `bun run test:unit` — 1283 pass / 0 fail
- [x] Measured: 4304 tok baseline → 2895 (C1) → 2159 (C2). 49.8% reduction
- [x] Per-tool max: 286 → 200 (well under any reasonable ceiling)
- [ ] Manual: snapshot `/api/diagnostics/evals/recent` outcome rates pre- and post-deploy; compare for the high-traffic tools (geo_*, web_*, room_*). Flag any drop in success rate as a candidate for description restoration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)