### PR TITLE
fix(openai): support gpt-5 family + o-series (max_completion_tokens)

### DIFF
--- a/src/llm/openai-compatible.test.ts
+++ b/src/llm/openai-compatible.test.ts
@@ -369,6 +369,75 @@ describe('createOpenAICompatibleProvider', () => {
     }
   })
 
+  test('gpt-5 family: max_tokens sent as max_completion_tokens (legacy field rejected by API)', async () => {
+    const fx = startFixture(() => ({
+      status: 200,
+      body: JSON.stringify({ choices: [{ message: { role: 'assistant', content: 'ok' } }] }),
+    }))
+    try {
+      const provider = createOpenAICompatibleProvider({ name: 'openai', getBaseUrl: () => fx.url, getApiKey: () => 'k' })
+      await provider.chat({ model: 'gpt-5.1', messages: [{ role: 'user', content: 'hi' }], maxTokens: 1024 })
+      expect(fx.last.body).toMatchObject({ model: 'gpt-5.1', max_completion_tokens: 1024 })
+      expect(fx.last.body).not.toHaveProperty('max_tokens')
+    } finally { fx.stop() }
+  })
+
+  test('gpt-5-mini: also uses max_completion_tokens', async () => {
+    const fx = startFixture(() => ({
+      status: 200,
+      body: JSON.stringify({ choices: [{ message: { role: 'assistant', content: 'ok' } }] }),
+    }))
+    try {
+      const provider = createOpenAICompatibleProvider({ name: 'openai', getBaseUrl: () => fx.url, getApiKey: () => 'k' })
+      await provider.chat({ model: 'gpt-5-mini', messages: [{ role: 'user', content: 'hi' }], maxTokens: 512 })
+      expect(fx.last.body).toMatchObject({ max_completion_tokens: 512 })
+      expect(fx.last.body).not.toHaveProperty('max_tokens')
+    } finally { fx.stop() }
+  })
+
+  test('o-series reasoning model: max_completion_tokens + temperature stripped', async () => {
+    const fx = startFixture(() => ({
+      status: 200,
+      body: JSON.stringify({ choices: [{ message: { role: 'assistant', content: 'ok' } }] }),
+    }))
+    try {
+      const provider = createOpenAICompatibleProvider({ name: 'openai', getBaseUrl: () => fx.url, getApiKey: () => 'k' })
+      await provider.chat({ model: 'o1', messages: [{ role: 'user', content: 'hi' }], maxTokens: 256, temperature: 0.7 })
+      expect(fx.last.body).toMatchObject({ max_completion_tokens: 256 })
+      expect(fx.last.body).not.toHaveProperty('max_tokens')
+      // o-series rejects temperature overrides — adapter must omit it
+      expect(fx.last.body).not.toHaveProperty('temperature')
+    } finally { fx.stop() }
+  })
+
+  test('legacy gpt-4o: still uses max_tokens (regression guard)', async () => {
+    const fx = startFixture(() => ({
+      status: 200,
+      body: JSON.stringify({ choices: [{ message: { role: 'assistant', content: 'ok' } }] }),
+    }))
+    try {
+      const provider = createOpenAICompatibleProvider({ name: 'openai', getBaseUrl: () => fx.url, getApiKey: () => 'k' })
+      await provider.chat({ model: 'gpt-4o', messages: [{ role: 'user', content: 'hi' }], maxTokens: 800, temperature: 0.5 })
+      expect(fx.last.body).toMatchObject({ max_tokens: 800, temperature: 0.5 })
+      expect(fx.last.body).not.toHaveProperty('max_completion_tokens')
+    } finally { fx.stop() }
+  })
+
+  test('gpt-5.1 with provider-prefixed model ref: still routed to max_completion_tokens', async () => {
+    // System.llm.chat normalises prefixes off, but routes that go through
+    // the gateway with a prefixed ref still hit this adapter. Guard the
+    // matcher against the `openai:` prefix shape.
+    const fx = startFixture(() => ({
+      status: 200,
+      body: JSON.stringify({ choices: [{ message: { role: 'assistant', content: 'ok' } }] }),
+    }))
+    try {
+      const provider = createOpenAICompatibleProvider({ name: 'openai', getBaseUrl: () => fx.url, getApiKey: () => 'k' })
+      await provider.chat({ model: 'openai:gpt-5.1', messages: [{ role: 'user', content: 'hi' }], maxTokens: 100 })
+      expect(fx.last.body).toMatchObject({ max_completion_tokens: 100 })
+    } finally { fx.stop() }
+  })
+
   test('failover safety: input ChatRequest.tools reference is unchanged after Anthropic call', async () => {
     const fx = startFixture(() => ({ status: 200, body: okBody }))
     try {

--- a/src/llm/openai-compatible.ts
+++ b/src/llm/openai-compatible.ts
@@ -249,6 +249,31 @@ const toOAIMessages = (request: ChatRequest, providerName: string): OAIMessage[]
   return request.messages.map(m => ({ role: m.role, content: m.content }))
 }
 
+// OpenAI's gpt-5 family AND the o-series reasoning models (o1, o3, o4)
+// rejected the legacy `max_tokens` field in favour of
+// `max_completion_tokens`, and the o-series additionally rejects any
+// `temperature` other than the default. We detect by model prefix so the
+// rule applies on OpenAI, OpenRouter (which proxies these), and any
+// future provider that re-exposes the same models.
+//
+// Match by NORMALISED model id (no provider prefix). Callers pass
+// `request.model` which may include a `<prov>:` prefix — strip it before
+// matching.
+const stripProviderPrefix = (model: string): string => {
+  const idx = model.indexOf(':')
+  return idx >= 0 ? model.slice(idx + 1) : model
+}
+const usesMaxCompletionTokens = (model: string): boolean => {
+  const id = stripProviderPrefix(model).toLowerCase()
+  return id.startsWith('gpt-5') || /^o[1-9]/.test(id)
+}
+const rejectsTemperature = (model: string): boolean => {
+  const id = stripProviderPrefix(model).toLowerCase()
+  // o-series reasoning models reject any temperature override. gpt-5
+  // chat models accept temperature, so we only gate on o\d here.
+  return /^o[1-9]/.test(id)
+}
+
 const buildOAIBody = (request: ChatRequest, stream: boolean, providerName: string): Record<string, unknown> => {
   const body: Record<string, unknown> = {
     model: request.model,
@@ -258,13 +283,21 @@ const buildOAIBody = (request: ChatRequest, stream: boolean, providerName: strin
   // Ask providers to include a final usage frame (supported by OpenAI, Groq,
   // Cerebras, OpenRouter). Providers that don't support it ignore the flag.
   if (stream) body.stream_options = { include_usage: true }
-  if (request.temperature !== undefined) body.temperature = request.temperature
+  if (request.temperature !== undefined && !rejectsTemperature(request.model)) {
+    body.temperature = request.temperature
+  }
   // Seed is emitted to every OpenAI-shape provider. Providers that support it
   // (OpenAI, Groq, Cerebras, OpenRouter, Mistral, SambaNova) honor it; those
   // that don't (Anthropic, Gemini) silently discard unknown fields. Keep the
   // plumbing uniform; document per-provider coverage in the README.
   if (request.seed !== undefined) body.seed = request.seed
-  if (request.maxTokens !== undefined) body.max_tokens = request.maxTokens
+  if (request.maxTokens !== undefined) {
+    if (usesMaxCompletionTokens(request.model)) {
+      body.max_completion_tokens = request.maxTokens
+    } else {
+      body.max_tokens = request.maxTokens
+    }
+  }
   if (request.jsonMode) body.response_format = { type: 'json_object' }
   if (request.tools && request.tools.length > 0) {
     // Anthropic-only: attach `cache_control: ephemeral` (top-level on the


### PR DESCRIPTION
## Summary

User hit this testing gpt-5.1 in production:

> \`Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.\`

The OpenAI gpt-5 family and the o-series reasoning models (o1, o3, o4) rejected the legacy \`max_tokens\` field. The adapter unconditionally sent it, so every call to a gpt-5 / o-series model hit a 400 before reaching the model. Compounding the issue: the router treats this as non-fallbackable (correctly — it's a request-shape error, not a transient one), so no failover.

## Fix

[openai-compatible.ts](src/llm/openai-compatible.ts:252) — detect by normalised model-id prefix:

- \`gpt-5*\` → \`max_completion_tokens\`
- \`o[1-9]*\` → \`max_completion_tokens\` **AND omit \`temperature\`** (the o-series rejects temperature overrides)
- everything else → legacy \`max_tokens\` (unchanged)

Provider-prefixed refs (\`openai:gpt-5.1\`) are stripped before matching.

## Test plan

- [x] \`bun run check\`
- [x] \`bun run test:unit\` — 1288 pass / 0 fail (+5 new tests)
- [x] gpt-5.1 / gpt-5-mini / o1 / gpt-4o (regression) / openai-prefixed all covered
- [ ] Manual: click Test on the gpt-5.1 entry in the Providers panel — should succeed where it previously 400'd

🤖 Generated with [Claude Code](https://claude.com/claude-code)