### PR TITLE
fix(openai): gpt-5 temperature; add gitSha to /api/system/info

### DIFF
--- a/src/api/routes/system.ts
+++ b/src/api/routes/system.ts
@@ -12,8 +12,21 @@ import { json, errorResponse, parseBody } from './helpers.ts'
 import type { RouteEntry } from './types.ts'
 import { authEnabled, buildSessionCookie, issueSession, validateToken, getAuthLimiter } from '../auth.ts'
 
-// Cached on first read. package.json doesn't change at runtime.
-let cachedInfo: { version: string; repoUrl: string } | null = null
+// Cached on first read. package.json doesn't change at runtime; the git
+// SHA is captured once from the working tree the process was launched
+// from. Both stable for the lifetime of the process.
+interface SystemInfo {
+  readonly version: string
+  readonly repoUrl: string
+  // Short git SHA of HEAD when the process started. Empty string when
+  // not in a git tree (e.g. release tarball, container without .git).
+  // Used by ops to verify a deploy actually picked up the latest master
+  // — invaluable when prod looks like it should have the fix but the
+  // user sees old behaviour. Without this field, the only way to
+  // verify the running binary's source is to SSH in.
+  readonly gitSha: string
+}
+let cachedInfo: SystemInfo | null = null
 
 const normalizeRepoUrl = (raw: unknown): string => {
   if (typeof raw === 'string') return raw.replace(/^git\+/, '').replace(/\.git$/, '')
@@ -23,7 +36,25 @@ const normalizeRepoUrl = (raw: unknown): string => {
   return ''
 }
 
-const readPackageInfo = async (): Promise<{ version: string; repoUrl: string }> => {
+// Capture the SHA at startup via a one-shot `git rev-parse --short HEAD`.
+// Synchronous Bun spawn keeps boot-time uniform — failure (no git, no .git
+// dir) returns ''. Bun.spawnSync is available since Bun 1.0.
+const readGitSha = (): string => {
+  try {
+    const result = Bun.spawnSync({
+      cmd: ['git', 'rev-parse', '--short', 'HEAD'],
+      cwd: process.cwd(),
+      stdout: 'pipe',
+      stderr: 'ignore',
+    })
+    if (result.exitCode !== 0) return ''
+    return new TextDecoder().decode(result.stdout).trim()
+  } catch {
+    return ''
+  }
+}
+
+const readPackageInfo = async (): Promise<SystemInfo> => {
   if (cachedInfo) return cachedInfo
   try {
     const raw = await readFile(resolve(process.cwd(), 'package.json'), 'utf-8')
@@ -31,9 +62,10 @@ const readPackageInfo = async (): Promise<{ version: string; repoUrl: string }> 
     cachedInfo = {
       version: pkg.version ?? '0.0.0',
       repoUrl: normalizeRepoUrl(pkg.repository),
+      gitSha: readGitSha(),
     }
   } catch {
-    cachedInfo = { version: '0.0.0', repoUrl: '' }
+    cachedInfo = { version: '0.0.0', repoUrl: '', gitSha: readGitSha() }
   }
   return cachedInfo
 }

--- a/src/llm/openai-compatible.test.ts
+++ b/src/llm/openai-compatible.test.ts
@@ -410,6 +410,24 @@ describe('createOpenAICompatibleProvider', () => {
     } finally { fx.stop() }
   })
 
+  test('gpt-5 family: temperature stripped too (gpt-5 only accepts default 1.0)', async () => {
+    // Discovered while debugging prod: after the max_tokens → max_completion_tokens
+    // fix landed, the test-model endpoint's temperature:0 caused the SAME
+    // shape of 400 from gpt-5. The new-family detection applies to BOTH
+    // fields, not just max_tokens.
+    const fx = startFixture(() => ({
+      status: 200,
+      body: JSON.stringify({ choices: [{ message: { role: 'assistant', content: 'ok' } }] }),
+    }))
+    try {
+      const provider = createOpenAICompatibleProvider({ name: 'openai', getBaseUrl: () => fx.url, getApiKey: () => 'k' })
+      await provider.chat({ model: 'gpt-5.1', messages: [{ role: 'user', content: 'hi' }], maxTokens: 1, temperature: 0 })
+      expect(fx.last.body).toMatchObject({ max_completion_tokens: 1 })
+      expect(fx.last.body).not.toHaveProperty('max_tokens')
+      expect(fx.last.body).not.toHaveProperty('temperature')
+    } finally { fx.stop() }
+  })
+
   test('legacy gpt-4o: still uses max_tokens (regression guard)', async () => {
     const fx = startFixture(() => ({
       status: 200,

--- a/src/llm/openai-compatible.ts
+++ b/src/llm/openai-compatible.ts
@@ -250,29 +250,32 @@ const toOAIMessages = (request: ChatRequest, providerName: string): OAIMessage[]
 }
 
 // OpenAI's gpt-5 family AND the o-series reasoning models (o1, o3, o4)
-// rejected the legacy `max_tokens` field in favour of
-// `max_completion_tokens`, and the o-series additionally rejects any
-// `temperature` other than the default. We detect by model prefix so the
-// rule applies on OpenAI, OpenRouter (which proxies these), and any
-// future provider that re-exposes the same models.
+// require `max_completion_tokens` instead of the legacy `max_tokens`,
+// AND reject any `temperature` other than the default (1.0). We detect
+// by model prefix so the rule applies on OpenAI, OpenRouter (which
+// proxies these), and any future provider that re-exposes the same
+// models.
 //
 // Match by NORMALISED model id (no provider prefix). Callers pass
 // `request.model` which may include a `<prov>:` prefix — strip it before
 // matching.
+//
+// Failure modes prevented:
+//   - HTTP 400 "Unsupported parameter: 'max_tokens' ... Use
+//     'max_completion_tokens' instead." (gpt-5*, o[1-9]*)
+//   - HTTP 400 "Unsupported value: 'temperature' does not support 0
+//     with this model. Only the default (1) value is supported."
+//     (gpt-5*, o[1-9]*)
 const stripProviderPrefix = (model: string): string => {
   const idx = model.indexOf(':')
   return idx >= 0 ? model.slice(idx + 1) : model
 }
-const usesMaxCompletionTokens = (model: string): boolean => {
+const isNewOpenAIFamily = (model: string): boolean => {
   const id = stripProviderPrefix(model).toLowerCase()
   return id.startsWith('gpt-5') || /^o[1-9]/.test(id)
 }
-const rejectsTemperature = (model: string): boolean => {
-  const id = stripProviderPrefix(model).toLowerCase()
-  // o-series reasoning models reject any temperature override. gpt-5
-  // chat models accept temperature, so we only gate on o\d here.
-  return /^o[1-9]/.test(id)
-}
+const usesMaxCompletionTokens = isNewOpenAIFamily
+const rejectsTemperature = isNewOpenAIFamily
 
 const buildOAIBody = (request: ChatRequest, stream: boolean, providerName: string): Record<string, unknown> => {
   const body: Record<string, unknown> = {

--- a/src/ui/modules/modals/bug-modal.ts
+++ b/src/ui/modules/modals/bug-modal.ts
@@ -12,19 +12,19 @@
 
 import { showToast } from '../toast.ts'
 
-interface SystemInfo { readonly version: string }
+interface SystemInfo { readonly version: string; readonly gitSha?: string }
 
-let cachedVersion: string | null = null
+let cachedInfo: { version: string; gitSha: string } | null = null
 
-const fetchVersion = async (): Promise<string> => {
-  if (cachedVersion !== null) return cachedVersion
+const fetchVersion = async (): Promise<{ version: string; gitSha: string }> => {
+  if (cachedInfo !== null) return cachedInfo
   try {
     const res = await fetch('/api/system/info')
-    if (!res.ok) return ''
+    if (!res.ok) return { version: '', gitSha: '' }
     const info = await res.json() as Partial<SystemInfo>
-    cachedVersion = info.version ?? ''
-    return cachedVersion
-  } catch { return '' }
+    cachedInfo = { version: info.version ?? '', gitSha: info.gitSha ?? '' }
+    return cachedInfo
+  } catch { return { version: '', gitSha: '' } }
 }
 
 export const openBugModal = async (): Promise<void> => {
@@ -42,9 +42,12 @@ export const openBugModal = async (): Promise<void> => {
   descEl.value = ''
   submitBtn.disabled = false
 
-  const version = await fetchVersion()
+  const { version, gitSha } = await fetchVersion()
+  const versionLabel = version
+    ? (gitSha ? `${version} (${gitSha})` : version)
+    : '(version unknown)'
   const ua = navigator.userAgent
-  ctxEl.textContent = `Will include: samsinn ${version || '(version unknown)'} · ${ua}`
+  ctxEl.textContent = `Will include: samsinn ${versionLabel} · ${ua}`
 
   cancelBtn.onclick = () => dlg.close()
   dlg.addEventListener('cancel', () => dlg.close())
@@ -59,7 +62,7 @@ export const openBugModal = async (): Promise<void> => {
       const res = await fetch('/api/bugs', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title, description, version, userAgent: ua }),
+        body: JSON.stringify({ title, description, version: versionLabel, userAgent: ua }),
       })
       if (res.status === 201) {
         const body = await res.json().catch(() => ({})) as { htmlUrl?: string; number?: number }


### PR DESCRIPTION
## Summary

Two changes pulled together by today's prod debug session.

**1. gpt-5 family also rejects temperature overrides.**

Follow-up to [f3095cf](../../commit/f3095cf). After \`max_tokens → max_completion_tokens\` landed, the providers-panel Test button still 400'd against gpt-5.1. Cause: the test-model endpoint sends \`temperature: 0\` and gpt-5 family only accepts the default \`1.0\`. Same shape of "Unsupported parameter" error.

The new-OpenAI-family detection (\`gpt-5*\`, \`o[1-9]*\`) now drives BOTH field rules. Renamed predicate to \`isNewOpenAIFamily\` so the intent is one place.

**2. Add gitSha to /api/system/info.**

Today, prod said "deploy succeeded" and the user said "same problem". I had no way to verify which commit was actually running on the server without SSH credentials. \`/api/system/info\` reported only package.json version (which doesn't change every commit), so a pulled-but-not-restarted state was indistinguishable from "actually running latest."

\`gitSha\` is captured once at startup via \`git rev-parse --short HEAD\` (Bun.spawnSync, no extra deps). Empty string when not in a git tree (release tarball / container). Bug-modal surfaces it as \`samsinn 0.13.0 (14bea15)\` so the user can copy it into a bug report.

Without this, the only verification path was "SSH in and read the source" — exactly what blocks diagnosing deploys-from-the-outside.

## Test plan

- [x] \`bun run check\`
- [x] \`bun run test:unit\` — 1289 pass / 0 fail (+1 new test: gpt-5 temperature stripping)
- [x] Adapter tests: 22 pass (was 21)
- [ ] Manual after deploy: \`curl https://samsinn.app/api/system/info | jq .gitSha\` should return the merged-master short SHA
- [ ] Manual after deploy: click Test on gpt-5.1 in Providers panel → should now succeed (or fail with a *different* error pointing to the next real issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)