### PR TITLE
fix(providers-test): bump ping maxTokens for gpt-5 reasoning floor

### DIFF
--- a/src/api/routes/providers-test.ts
+++ b/src/api/routes/providers-test.ts
@@ -142,7 +142,14 @@ export const providersTestRoutes: RouteEntry[] = [
 
       const t0 = performance.now()
       try {
-        const resp = await provider.chat({ model, messages: [{ role: 'user', content: 'ping' }], maxTokens: 1, temperature: 0 })
+        // maxTokens=1024 covers gpt-5 reasoning floor (~1024 tokens of
+        // internal reasoning before any output). Legacy chat models still
+        // respond in 5-10 tokens, so this only costs more for new-family
+        // pings. User-clicked test → cost is negligible (~$0.001 max).
+        // temperature is omitted; the adapter strips it for new-family
+        // models anyway (gpt-5 only accepts default 1.0), and legacy
+        // models will use their default which is fine for a ping.
+        const resp = await provider.chat({ model, messages: [{ role: 'user', content: 'ping' }], maxTokens: 1024 })
         system.monitors[name]?.recordHeartbeat(true)
         return json({
           ok: true, elapsedMs: Math.round(performance.now() - t0),
@@ -202,7 +209,7 @@ export const providersTestRoutes: RouteEntry[] = [
         const target = Math.max(1, system.providerConfig.ollamaMaxConcurrent || 2)
         const raw = createOllamaProvider(system.providerConfig.ollamaUrl)
         const probe = await runProbe(
-          async (m) => { await raw.chat({ model: m, messages: [{ role: 'user', content: 'ping' }], maxTokens: 1, temperature: 0 }) },
+          async (m) => { await raw.chat({ model: m, messages: [{ role: 'user', content: 'ping' }], maxTokens: 1024 }) },
           model, target, TEST_TIMEOUT_MS,
         )
 
@@ -302,7 +309,7 @@ export const providersTestRoutes: RouteEntry[] = [
       if (model) {
         const target = Math.max(1, mergedAgain.cloud[name]?.maxConcurrent ?? PROVIDER_PROFILES[name].defaultMaxConcurrent)
         concurrency = await runProbe(
-          async (m) => { await provider.chat({ model: m, messages: [{ role: 'user', content: 'ping' }], maxTokens: 1, temperature: 0 }) },
+          async (m) => { await provider.chat({ model: m, messages: [{ role: 'user', content: 'ping' }], maxTokens: 1024 }) },
           model, target, TEST_TIMEOUT_MS,
         )
       }


### PR DESCRIPTION
## Summary

Third pass on the gpt-5 saga. After the adapter fixes landed, the Test button on gpt-5.4-mini returned a NEW 400:

> \`Could not finish the message because max_tokens or model output limit was reached.\`

Cause: gpt-5 family burns ~1024 tokens of internal reasoning **before** emitting any output. The test endpoint sent \`maxTokens: 1\` — works for legacy chat models that respond "pong" in 5 tokens, never going to work for a reasoning model.

Bumped \`maxTokens\` 1 → 1024 across the three ping call sites in [providers-test.ts](src/api/routes/providers-test.ts):
1. Single-model test (Ollama path)
2. Cloud-provider single-model test
3. Concurrency probe

Cost: a user-clicked test. ~$0.001 max on gpt-5-mini. Negligible.

Also dropped \`temperature: 0\` from the ping at the same time — the adapter strips it for new-family models anyway, and legacy models use their default which is fine for a ping.

## Test plan

- [x] \`bun run check\`
- [x] \`bun run test:unit\` — 1289 pass / 0 fail
- [ ] Manual after deploy: \`curl /api/system/info\` → \`gitSha\` reflects this merge
- [ ] Manual after deploy: click Test on gpt-5.4-mini in Providers panel → \`ok: true\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)