### PR TITLE
fix: geo_list_features XOR hint + gpt-5 context-window table

### DIFF
--- a/src/llm/models/context-window.test.ts
+++ b/src/llm/models/context-window.test.ts
@@ -1,0 +1,72 @@
+// Synchronous context-window lookup tests. The async path that hits
+// /api/show or /models is not exercised here — getContextWindowSync is
+// the hot path (called by ai-agent factory on every spawn) and the one
+// that drives the UI's per-message %-of-context indicator.
+
+import { describe, test, expect } from 'bun:test'
+import { getContextWindowSync } from './context-window.ts'
+
+describe('getContextWindowSync', () => {
+  test('exact-match curated entry: gpt-4o', () => {
+    const info = getContextWindowSync('openai', 'gpt-4o')
+    expect(info.source).toBe('known_table')
+    expect(info.contextMax).toBe(128_000)
+  })
+
+  test('exact-match gpt-5 family: gpt-5.4-mini', () => {
+    const info = getContextWindowSync('openai', 'gpt-5.4-mini')
+    expect(info.source).toBe('known_table')
+    expect(info.contextMax).toBe(400_000)
+  })
+
+  test('exact-match gpt-5-nano: smaller window', () => {
+    const info = getContextWindowSync('openai', 'gpt-5-nano')
+    expect(info.contextMax).toBe(200_000)
+  })
+
+  test('exact-match o-series: o3-mini', () => {
+    const info = getContextWindowSync('openai', 'o3-mini')
+    expect(info.contextMax).toBe(200_000)
+  })
+
+  test('OpenAI dated snapshot resolves via longest-prefix fallback', () => {
+    // OpenAI ships dated snapshots constantly. Without the prefix matcher
+    // these all show as '?%' in the UI's per-message token indicator
+    // — exactly the bug that surfaced in prod when the UI couldn't
+    // resolve gpt-5.4-mini's snapshot.
+    const info = getContextWindowSync('openai', 'gpt-5.4-mini-2026-03-17')
+    expect(info.source).toBe('known_table')
+    expect(info.contextMax).toBe(400_000)
+  })
+
+  test('longest-prefix match: gpt-5.1-mini-2026-04-01 picks the gpt-5.1-mini entry, not gpt-5.1', () => {
+    // The matcher must prefer the most specific prefix. gpt-5.1 and
+    // gpt-5.1-mini are different entries (both 400k in this case, but
+    // the rule matters for gpt-5-nano which is 200k vs gpt-5 which is
+    // 400k).
+    const info = getContextWindowSync('openai', 'gpt-5.1-mini-2026-04-01')
+    expect(info.contextMax).toBe(400_000)
+  })
+
+  test('longest-prefix distinguishes gpt-5-nano (200k) from gpt-5 (400k)', () => {
+    const nano = getContextWindowSync('openai', 'gpt-5-nano-2026-08-07')
+    expect(nano.contextMax).toBe(200_000)
+    const full = getContextWindowSync('openai', 'gpt-5-2026-08-07')
+    expect(full.contextMax).toBe(400_000)
+  })
+
+  test('unknown model resolves to unknown (not silently fabricated)', () => {
+    const info = getContextWindowSync('openai', 'gpt-99-from-the-future')
+    expect(info.source).toBe('unknown')
+    expect(info.contextMax).toBe(0)
+  })
+
+  test('prefix fallback is OpenAI-only — other providers keep exact match', () => {
+    // Anthropic / Gemini / Groq don't ship dated snapshots the same way,
+    // and their models have stable names. Restricting the prefix matcher
+    // to OpenAI prevents false matches like `claude-haiku-4-5-something`
+    // accidentally getting Anthropic's 200k.
+    const info = getContextWindowSync('anthropic', 'claude-haiku-4-5-something')
+    expect(info.source).toBe('unknown')
+  })
+})

--- a/src/llm/models/context-window.ts
+++ b/src/llm/models/context-window.ts
@@ -27,6 +27,25 @@ const CLOUD_TABLE: Record<string, Record<string, number>> = {
     'gpt-4o':       128_000,
     'gpt-4.1-mini': 1_047_576,
     'gpt-4.1':      1_047_576,
+    // gpt-5 family + o-series. Exact-match on the family head; dated
+    // snapshots (e.g. 'gpt-5.4-mini-2026-03-17') fall through to the
+    // prefix matcher below.
+    'gpt-5':        400_000,
+    'gpt-5-mini':   400_000,
+    'gpt-5-nano':   200_000,
+    'gpt-5-pro':    400_000,
+    'gpt-5.1':      400_000,
+    'gpt-5.1-mini': 400_000,
+    'gpt-5.1-pro':  400_000,
+    'gpt-5.4':      400_000,
+    'gpt-5.4-mini': 400_000,
+    'gpt-5.4-nano': 200_000,
+    'gpt-5.4-pro':  400_000,
+    'o1':           200_000,
+    'o1-mini':      128_000,
+    'o3':           200_000,
+    'o3-mini':      200_000,
+    'o4-mini':      200_000,
   },
   gemini: {
     'gemini-2.5-flash-lite': 1_048_576,
@@ -127,10 +146,28 @@ export const getContextWindow = async (
   if (info.source === 'unknown') {
     const hard = CLOUD_TABLE[providerName]?.[modelId]
     if (hard) info = { contextMax: hard, source: 'known_table' }
+    else if (providerName === 'openai') {
+      const prefix = findOpenAIPrefixMatch(modelId)
+      if (prefix) info = { contextMax: prefix, source: 'known_table' }
+    }
   }
 
   cache.set(key, info)
   return info
+}
+
+// Longest-prefix fallback for OpenAI dated/minor variants. OpenAI ships
+// dated snapshots like `gpt-5.4-mini-2026-03-17` constantly; without a
+// prefix match they'd all show '?%' until someone hand-curates each one.
+// Sorted descending by length so the most specific match wins.
+const findOpenAIPrefixMatch = (modelId: string): number | undefined => {
+  const openai = CLOUD_TABLE['openai']
+  if (!openai) return undefined
+  const candidates = Object.keys(openai).sort((a, b) => b.length - a.length)
+  for (const key of candidates) {
+    if (modelId === key || modelId.startsWith(`${key}-`)) return openai[key]
+  }
+  return undefined
 }
 
 // Synchronous best-effort lookup — hits the in-process cache and the curated
@@ -143,5 +180,12 @@ export const getContextWindowSync = (providerName: string, modelId: string): Con
   if (cached) return cached
   const hard = CLOUD_TABLE[providerName]?.[modelId]
   if (hard) return { contextMax: hard, source: 'known_table' }
+  // OpenAI-only longest-prefix fallback for dated variants. Other providers
+  // either expose context via API (Ollama, OpenRouter) or have stable model
+  // names that don't churn.
+  if (providerName === 'openai') {
+    const prefix = findOpenAIPrefixMatch(modelId)
+    if (prefix) return { contextMax: prefix, source: 'known_table' }
+  }
   return { contextMax: 0, source: 'unknown' }
 }

--- a/src/tools/built-in/geo-tools.ts
+++ b/src/tools/built-in/geo-tools.ts
@@ -355,7 +355,12 @@ const MAX_LIMIT = 1000
 
 export const createGeoListFeaturesTool = (): Tool => ({
   name: 'geo_list_features',
-  description: 'List features in a category, optionally filtered by country / operator / name-substring / tag. Paste `data.renderable` verbatim into your reply to render the map inline.',
+  // The XOR constraint (category OR categoryHint, one required) is NOT
+  // expressible in plain JSON Schema, so it MUST live in the description
+  // — without it, models call with empty args, get an error, and reflect
+  // it back to the user as confusion. The `renderable` paste contract is
+  // also folded in here (per the post-2026-05 style: returns is UI-only).
+  description: 'List features in a category, optionally filtered by country / operator / name-substring / tag. Pass `category` (exact id) OR `categoryHint` (fuzzy) — one required. Paste `data.renderable` verbatim into your reply to render the map inline.',
   usage: 'Pass `category` (exact id) OR `categoryHint` (e.g. "oil platforms"). On ambiguous hint, the call errors with the candidate ids so you can clarify with the user. Filters compose (AND): country=ISO-3166-1-alpha-2, operator=substring, nameContains=substring on name+aliases, tag=exact match. Drop `data.renderable` verbatim into your chat reply to render the map inline.',
   returns: '{ features: [...], view?: {center, zoom}, count, totalMatched, truncated, category, source: "merged", renderable: "```map\\n{...}\\n```" }, or { success:false, error, candidates? } on ambiguity.',
   parameters: {


### PR DESCRIPTION
## Summary

Two bugs from the same prod screenshot (gpt-5.4-mini in Cafe room).

**Bug 1: agent refused to call geo_list_features**

The chat showed gpt-5-mini repeatedly asking the user to "pass category or categoryHint" instead of just calling the tool. Cause: the tool params have \`required: []\` because category vs categoryHint is XOR — and JSON Schema can't express XOR. The previous description said "Pass \`category\` (exact id) OR \`categoryHint\` (fuzzy) — one required." My 2026-05 cost-audit tightening cut that sentence. Model had no way to know.

Restored. This is the "non-obvious constraint" case the style rules explicitly allow a second clause for.

**Bug 2: "?%" instead of context-% indicator on gpt-5 messages**

Same screenshot showed "?%" in the AI message header where there should be a context-usage percentage. Cause: gpt-5 family wasn't in [context-window.ts](src/llm/models/context-window.ts)'s curated table, so \`getContextWindowSync\` returned \`contextMax: 0\`, which triggers the "?%" branch in render-message.ts.

Fix:
- Added gpt-5 family (\`gpt-5\`, \`gpt-5.1\`, \`gpt-5.4\` × \`-mini\`/\`-nano\`/\`-pro\` variants) and o-series at their published context windows
- Added a longest-prefix fallback for OpenAI specifically — OpenAI ships dated snapshots (\`gpt-5.4-mini-2026-03-17\`) constantly; without prefix matching every snapshot would show "?%" until hand-curated. Restricted to OpenAI because other providers' names are stable
- Same fallback in both sync (UI indicator) and async (agent factory's context-budget) paths

9 new tests covering exact / prefix / longest-prefix / unknown / provider-scoping.

## Test plan

- [x] \`bun run check\`
- [x] \`bun run test:unit\` — 1298 pass / 0 fail (+9 new)
- [ ] Manual after deploy: ask gpt-5.4-mini "show map of norwegian oil platforms" → should call the tool with categoryHint, not loop
- [ ] Manual after deploy: gpt-5.4-mini messages should show a numeric % (e.g. \`14%\`) instead of \`?%\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)