### PR TITLE
fix(geo): country filter tolerates 'norwegian' / 'Norway' (not just 'NO')

### DIFF
--- a/src/tools/built-in/geo-tools.test.ts
+++ b/src/tools/built-in/geo-tools.test.ts
@@ -206,6 +206,42 @@ describe('geo_list_features', () => {
     }
   })
 
+  test('country filter accepts adjectival form ("norwegian")', async () => {
+    // LLMs reliably pass adjectival forms instead of ISO codes. Pre-fix,
+    // these returned 0 features and triggered retry loops. Normalisation
+    // maps norwegian → NO so the filter still works.
+    await seedFeature('Statfjord A', 61.25, 1.85, { country: 'NO' })
+    await seedFeature('Brent C', 61.0, 1.7, { country: 'GB' })
+    const r = await tool.execute({ category: 'oil-platforms', country: 'norwegian' }, fakeContext as never)
+    expect(r.success).toBe(true)
+    if (r.success) {
+      const d = r.data as { count: number }
+      expect(d.count).toBe(1)
+    }
+  })
+
+  test('country filter accepts full country name ("Norway")', async () => {
+    await seedFeature('Statfjord A', 61.25, 1.85, { country: 'NO' })
+    await seedFeature('Brent C', 61.0, 1.7, { country: 'GB' })
+    const r = await tool.execute({ category: 'oil-platforms', country: 'Norway' }, fakeContext as never)
+    expect(r.success).toBe(true)
+    if (r.success) {
+      const d = r.data as { count: number }
+      expect(d.count).toBe(1)
+    }
+  })
+
+  test('country filter still works with raw ISO code', async () => {
+    // Regression: alpha-2 short-circuit doesn't break legitimate ISO usage.
+    await seedFeature('Brent C', 61.0, 1.7, { country: 'GB' })
+    const r = await tool.execute({ category: 'oil-platforms', country: 'gb' }, fakeContext as never)
+    expect(r.success).toBe(true)
+    if (r.success) {
+      const d = r.data as { count: number }
+      expect(d.count).toBe(1)
+    }
+  })
+
   test('categoryHint matches by displayName substring', async () => {
     // Seed a feature with explicit category metadata so the projection
     // picks up "Oil Platforms" as the displayName.

--- a/src/tools/built-in/geo-tools.ts
+++ b/src/tools/built-in/geo-tools.ts
@@ -299,11 +299,47 @@ const fuzzyMatchCategory = (
   return { match: null, candidates: matches }
 }
 
+// LLMs reliably pass things like `country: "Norway"` or
+// `country: "norwegian"` instead of the ISO-3166-1 alpha-2 code we
+// store. The tool used to return 0 features in that case, leading to
+// retry loops. Normalise common country names and adjectival forms to
+// their alpha-2 code so the filter Just Works.
+// Kept deliberately small — the 30-odd entries below cover the
+// English-speaking model's likely outputs for the geographies we
+// actually have data for. Add more when a real miss shows up; don't
+// pre-populate every country in the world (token bloat in the eventual
+// description if we ever document this list).
+const COUNTRY_ALIASES: Record<string, string> = {
+  // adjectival forms
+  norwegian: 'NO', swedish: 'SE', danish: 'DK', finnish: 'FI', icelandic: 'IS',
+  british: 'GB', english: 'GB', scottish: 'GB', welsh: 'GB', irish: 'IE',
+  french: 'FR', german: 'DE', dutch: 'NL', belgian: 'BE', spanish: 'ES',
+  italian: 'IT', portuguese: 'PT', polish: 'PL', russian: 'RU', ukrainian: 'UA',
+  american: 'US', canadian: 'CA', mexican: 'MX', brazilian: 'BR',
+  chinese: 'CN', japanese: 'JP', korean: 'KR', australian: 'AU',
+  // full country names (when model gives e.g. "Norway")
+  norway: 'NO', sweden: 'SE', denmark: 'DK', finland: 'FI', iceland: 'IS',
+  'united kingdom': 'GB', uk: 'GB', britain: 'GB', 'great britain': 'GB',
+  ireland: 'IE', france: 'FR', germany: 'DE', netherlands: 'NL', holland: 'NL',
+  belgium: 'BE', spain: 'ES', italy: 'IT', portugal: 'PT', poland: 'PL',
+  russia: 'RU', ukraine: 'UA', 'united states': 'US', usa: 'US', america: 'US',
+  canada: 'CA', mexico: 'MX', brazil: 'BR', china: 'CN', japan: 'JP',
+  'south korea': 'KR', korea: 'KR', australia: 'AU',
+}
+
+const normalizeCountry = (raw: string): string => {
+  const trimmed = raw.trim()
+  if (!trimmed) return ''
+  // ISO-3166-1 alpha-2 short-circuit: 2 chars, all letters → assume code.
+  if (/^[A-Za-z]{2}$/.test(trimmed)) return trimmed.toUpperCase()
+  return COUNTRY_ALIASES[trimmed.toLowerCase()] ?? trimmed.toUpperCase()
+}
+
 const filterFeatures = (
   features: ReadonlyArray<GeoFeature>,
   filters: { country?: string; operator?: string; nameContains?: string; tag?: string },
 ): ReadonlyArray<GeoFeature> => {
-  const country = filters.country?.toUpperCase()
+  const country = filters.country ? normalizeCountry(filters.country) : undefined
   const operator = filters.operator?.toLowerCase()
   const nameContains = filters.nameContains?.toLowerCase()
   const tag = filters.tag?.toLowerCase()


### PR DESCRIPTION
## Summary

Hypothesised cause of the tool_loop_exceeded the user just saw on gpt-5.4-mini: the model passes \`country: "Norway"\` or \`country: "norwegian"\` to \`geo_list_features\`, the filter does an exact uppercase compare against \`"NO"\`, returns 0 features → model thinks "no results, retry with different args" → loops until the cap.

Added a small alias table (~30 entries) covering English adjectival forms (\`norwegian\` → \`NO\`), full country names (\`Norway\` → \`NO\`), and common UK/US variations. Alpha-2 codes short-circuit unchanged.

This is a defensive fix — would still benefit from seeing the actual trace to confirm this WAS the cause. The user can run \`fetch('/api/diagnostics/evals/recent?limit=3').then(r => r.json()).then(d => console.log(JSON.stringify(d, null, 2)))\` in DevTools console to dump the actual toolCalls of the failed eval.

## Test plan

- [x] \`bun run check\`
- [x] \`bun run test:unit\` — 1301 pass / 0 fail (+3 new)
- [ ] Manual after deploy: ask gpt-5.4-mini "show norwegian oil platforms on map" → should call geo_list_features with categoryHint + country, succeed, render the map

🤖 Generated with [Claude Code](https://claude.com/claude-code)