### PR TITLE
fix(geo_list_features): tell small models to skip the discovery dance

### DIFF
--- a/src/tools/built-in/geo-tools.ts
+++ b/src/tools/built-in/geo-tools.ts
@@ -391,12 +391,19 @@ const MAX_LIMIT = 1000
 
 export const createGeoListFeaturesTool = (): Tool => ({
   name: 'geo_list_features',
-  // The XOR constraint (category OR categoryHint, one required) is NOT
-  // expressible in plain JSON Schema, so it MUST live in the description
-  // — without it, models call with empty args, get an error, and reflect
-  // it back to the user as confusion. The `renderable` paste contract is
-  // also folded in here (per the post-2026-05 style: returns is UI-only).
-  description: 'List features in a category, optionally filtered by country / operator / name-substring / tag. Pass `category` (exact id) OR `categoryHint` (fuzzy) — one required. Paste `data.renderable` verbatim into your reply to render the map inline.',
+  // Two non-obvious contracts the LLM needs up front:
+  //   (1) The XOR constraint (category OR categoryHint, one required)
+  //       isn't expressible in JSON Schema → must live in prose.
+  //   (2) "When the user named a category in natural language, call THIS
+  //       directly with categoryHint — do not pre-discover with
+  //       geo_list_categories." Small reasoning models (observed:
+  //       gpt-5-mini) otherwise run a discovery → stop → ask-permission
+  //       loop that eats iterations and confuses the user. The fuzzy
+  //       matcher inside geo_list_features handles natural-language
+  //       category names directly.
+  //   (3) The `renderable` paste contract: returns is UI-only post-cost-
+  //       audit, so the fence-paste rule lives here.
+  description: 'List features in a category, optionally filtered by country / operator / name-substring / tag. Pass `category` (exact id) OR `categoryHint` (natural language, e.g. "oil platforms") — one required. Call directly when the user names a category — do not pre-list categories. Paste `data.renderable` verbatim into your reply to render the map inline.',
   usage: 'Pass `category` (exact id) OR `categoryHint` (e.g. "oil platforms"). On ambiguous hint, the call errors with the candidate ids so you can clarify with the user. Filters compose (AND): country=ISO-3166-1-alpha-2, operator=substring, nameContains=substring on name+aliases, tag=exact match. Drop `data.renderable` verbatim into your chat reply to render the map inline.',
   returns: '{ features: [...], view?: {center, zoom}, count, totalMatched, truncated, category, source: "merged", renderable: "```map\\n{...}\\n```" }, or { success:false, error, candidates? } on ambiguity.',
   parameters: {


### PR DESCRIPTION
## Summary

Prod observation on gpt-5.4-mini (after the XOR + country-alias fixes landed): the model still ran a discovery → ask-permission loop:

1. user: "show norwegian oil platforms on map"
2. model: calls \`geo_list_categories\` → finds "Oil Platforms"
3. model: "I found the right category. If you want, I can now fetch..." **stops, asks permission**

The fuzzy matcher inside \`geo_list_features\` already handles natural-language category names (\`"oil platforms"\` → \`oil-platforms\`). The discovery step was never necessary — small reasoning models just default to over-careful behaviour.

Added explicit "Call directly when the user names a category — do not pre-list categories" line to the description. ~10 tokens added; saves a whole eval iteration + a user permission turn per map request.

## Test plan

- [x] \`bun run check\`
- [x] \`bun run test:unit\` — 1301 pass / 0 fail
- [ ] Manual after deploy: "show norwegian oil platforms on map" on gpt-5.4-mini → single tool call to geo_list_features with categoryHint, map renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)