### PR TITLE
fix(defaults): historyLimit 10 → 100 for modern-context agents

### DIFF
--- a/src/core/types/constants.ts
+++ b/src/core/types/constants.ts
@@ -5,5 +5,13 @@ export const SYSTEM_SENDER_ID = 'system' as const
 export const DEFAULTS = {
   port: 3000,
   ollamaBaseUrl: 'http://127.0.0.1:11434',
-  historyLimit: 10,
+  // Per-agent room-history window (count, not tokens). The token budget
+  // (resolveContextTokenBudget in ai-agent.ts) auto-scales to 70% of the
+  // model's context window and is the real safety net — for modern
+  // models (gpt-5.4 = 1.05M, Claude = 200k, Gemini = 1M+) the 10-message
+  // legacy default cut off conversations the agent should remember.
+  // Set to 100: the token budget trims further if needed for small-
+  // context models. For Ollama with 8k context, ~50 messages typically
+  // fit; for gpt-5.4, all 100 plus most of history.
+  historyLimit: 100,
 } as const


### PR DESCRIPTION
## Summary

Prod observation: gpt-5.4 in the Cafe room couldn't recall a mapping question asked ~15 messages earlier in the same room. The agent said "I don't see a previous mapping question" even though the user could scroll up to it in the room.

Root cause: \`DEFAULTS.historyLimit = 10\`. The agent's per-room history window slices the LAST 10 messages BEFORE the token-budget trim runs. Made sense in the 4k-context era; comically restrictive against models with 200k–1M+ context. For gpt-5.4 (1.05M context, ~700k auto-budget), the 10-message slice was throwing away 99% of what the agent could have remembered.

Bumped to 100. The token budget (\`resolveContextTokenBudget\` = 70% of model context window) still trims further when needed:

- gpt-5.4 (1.05M) → ~700k tokens, all 100 fit
- Claude (200k) → ~140k, all 100 fit
- Gemini (1M+) → ~700k+, all 100 fit
- Ollama 8k → ~5.6k, ~30-50 messages typically fit (token-budget trims from front, as before)

Per-agent override (\`config.historyLimit\`) still works for dialling individual agents up or down.

## Test plan

- [x] \`bun run check\`
- [x] \`bun run test:unit\` — 1301 pass / 0 fail (3 test files explicitly pass historyLimit:10 to test tight-window trim behaviour; unaffected by default change)
- [ ] Manual after deploy: in a chat with 20+ messages, ask gpt-5.4 about something from 15 messages back → should recall it

🤖 Generated with [Claude Code](https://claude.com/claude-code)