### PR TITLE
fix(tool-surface): self-heal stale agent.tools containing dispatcher names

### DIFF
--- a/src/agents/spawn.ts
+++ b/src/agents/spawn.ts
@@ -18,7 +18,7 @@ import { createAIAgent } from './ai-agent.ts'
 import type { Decision } from './ai-agent.ts'
 import { callLLM, streamLLM } from './evaluation.ts'
 import { addAgentToRoom } from './actions.ts'
-import { createToolSurface, inferProviderFromModelRef } from '../tool-surface/index.ts'
+import { createToolSurface, inferProviderFromModelRef, FAMILY_DISPATCHER_NAMES } from '../tool-surface/index.ts'
 import { CURATED_MODELS } from '../llm/models/catalog.ts'
 
 // --- Tool executor ---
@@ -147,7 +147,14 @@ export interface AgentToolSupport {
 }
 
 const warnMissingTools = (agentName: string, requested: ReadonlyArray<string>, registry: ToolRegistry): void => {
-  const missing = requested.filter(n => !registry.has(n))
+  // Skip dispatcher names — they're expected to be absent from the
+  // registry as atomic entries. The surface synthesises them at
+  // projection time, the trampoline gets registered later in
+  // buildToolSupport, and expandFamilyAliases in tool-surface/index.ts
+  // turns stored dispatcher names into member names before they reach
+  // the candidate set. Treating them as "missing" was misleading and
+  // sent prod debugging down a rabbit hole (2026-05-12).
+  const missing = requested.filter(n => !registry.has(n) && !FAMILY_DISPATCHER_NAMES.has(n))
   if (missing.length > 0)
     console.warn(`[spawn] Agent "${agentName}": tools not found in registry: ${missing.join(', ')}`)
 }

--- a/src/tool-surface/index.ts
+++ b/src/tool-surface/index.ts
@@ -77,7 +77,38 @@ export interface CreateToolSurfaceDeps {
 
 export const createToolSurface = (deps: CreateToolSurfaceDeps): ToolSurface => {
   const families = deps.families ?? BUILT_IN_FAMILIES
-  const requestedSet = new Set(deps.requestedTools)
+
+  // Stale-snapshot self-heal: pre-trampoline-refactor (2026-05) snapshots
+  // captured family dispatcher names (`geo_tools`, `pack_admin`, ...) in
+  // agent.config.tools — those were "real" registered tools at the time.
+  // Post-refactor dispatchers are synthesized, not requested. A loaded
+  // agent whose requestedTools contains only dispatcher names + a few
+  // built-ins would silently end up with no geo capability at all
+  // (FAMILY_DISPATCHER_NAMES filter strips them from candidates; no
+  // members in requestedTools means compressFamilies finds nothing to
+  // compress; result: agent sees `pass` only and loops on map requests).
+  //
+  // Fix: when a dispatcher name appears in requestedTools, expand it to
+  // the family's underlying member names so the surface re-synthesises
+  // the dispatcher from real members. Doesn't migrate the snapshot;
+  // self-heals on every load.
+  const expandFamilyAliases = (names: ReadonlyArray<string>): ReadonlyArray<string> => {
+    if (names.every(n => !FAMILY_DISPATCHER_NAMES.has(n))) return names
+    const expanded = new Set<string>()
+    for (const name of names) {
+      if (!FAMILY_DISPATCHER_NAMES.has(name)) {
+        expanded.add(name)
+        continue
+      }
+      const family = families.find(f => f.name === name)
+      if (!family) continue
+      for (const entry of deps.registry.listEntries()) {
+        if (family.match(entry)) expanded.add(entry.tool.name)
+      }
+    }
+    return [...expanded]
+  }
+  const requestedSet = new Set(expandFamilyAliases(deps.requestedTools))
 
   // Compute once per project() call; member resolution is lazy so MCP /
   // pack lifecycle changes are picked up automatically.
@@ -98,10 +129,19 @@ export const createToolSurface = (deps: CreateToolSurfaceDeps): ToolSurface => {
   //      explicitly turned on.
   //
   // Family dispatcher names (geo_tools, fs, pack_admin, codegen_tools)
-  // are universally excluded from the candidate set — the compressed
-  // path re-synthesises them, the flat path wants the underlying tools,
-  // and including a stored dispatcher caused Gemini "Duplicate function
-  // declaration" failures (geo_tools synthesised + stored sharing a name).
+  // are universally excluded from the candidate set. THIS FILTER IS
+  // LOAD-BEARING — it prevents projection-time duplicate-function
+  // declarations on Gemini (commit b0fe8d3 was the prior incident:
+  // synthesised geo_tools + stored geo_tools shared a name and the
+  // request was rejected with HTTP 400 INVALID_ARGUMENT).
+  //
+  // expandFamilyAliases above turns stored dispatcher names INTO
+  // member names before this filter runs, so the typical stale-
+  // snapshot case never reaches here. But the filter is the last line
+  // for: (a) any future path that bypasses expansion, (b) registry
+  // entries that happen to share a name with a family. Do NOT remove
+  // without auditing both the projection and the executor against
+  // the duplicate-name failure mode.
   const buildCandidates = (roomId: string | undefined): ReadonlySet<string> => {
     const room = roomId && deps.getRoomActivation ? deps.getRoomActivation(roomId) : undefined
     const activeSet = room ? effectiveActivePackSet(room) : null

--- a/src/tool-surface/surface.integration.test.ts
+++ b/src/tool-surface/surface.integration.test.ts
@@ -195,6 +195,88 @@ describe('regression: dispatcher round-trip never produces duplicate function de
   })
 })
 
+describe('stale-snapshot self-heal: requestedTools containing dispatcher names', () => {
+  // Real prod bug 2026-05-12: pre-trampoline-refactor snapshots captured
+  // family dispatcher names (geo_tools, pack_admin, codegen_tools) in
+  // agent.config.tools. After the refactor, dispatchers are synthesised
+  // from members — a requestedTools list that only has dispatcher names
+  // (no underlying members) would produce an empty surface. The agent
+  // ended up with only `pass` and looped on map requests.
+  test('dispatcher name in requestedTools expands to family members → compression fires', () => {
+    const r = createToolRegistry()
+    // Underlying geo members in the registry — but the agent's
+    // requestedTools only has the DISPATCHER NAME (stale-snapshot shape).
+    for (const n of ['geo_lookup', 'geo_add', 'geo_remove']) r.register(mockTool(n, 100))
+    r.register(createPassTool())
+
+    const surface = createToolSurface({
+      registry: r,
+      requestedTools: ['pass', 'geo_tools'],  // dispatcher name only — no members listed
+    })
+    const compressed = surface.project(undefined, 'openai')
+    const names = compressed.map(d => d.function.name).sort()
+    // geo_tools dispatcher should be in the surface (synthesised from
+    // the expanded members), plus pass.
+    expect(names).toContain('geo_tools')
+    expect(names).toContain('pass')
+  })
+
+  test('dispatcher name absent → no expansion (regression guard)', () => {
+    // Normal case: requestedTools has member names directly. No expansion
+    // path runs; the existing compression behaviour is unchanged.
+    const r = createToolRegistry()
+    for (const n of ['geo_lookup', 'geo_add', 'geo_remove']) r.register(mockTool(n, 100))
+    r.register(createPassTool())
+
+    const surface = createToolSurface({
+      registry: r,
+      requestedTools: ['pass', 'geo_lookup', 'geo_add', 'geo_remove'],
+    })
+    const compressed = surface.project(undefined, 'openai')
+    const names = compressed.map(d => d.function.name).sort()
+    expect(names).toContain('geo_tools')
+    expect(names).toContain('pass')
+  })
+
+  test('dispatcher name + flat-strict provider: returns underlying member tools', () => {
+    // gemini path — dispatchers aren't sent. Expansion must still surface
+    // the underlying members.
+    const r = createToolRegistry()
+    for (const n of ['geo_lookup', 'geo_add', 'geo_remove']) r.register(mockTool(n, 100))
+    r.register(createPassTool())
+
+    const surface = createToolSurface({
+      registry: r,
+      requestedTools: ['pass', 'geo_tools'],
+    })
+    const flat = surface.project(undefined, 'gemini')
+    const names = flat.map(d => d.function.name).sort()
+    expect(names).toEqual(['geo_add', 'geo_lookup', 'geo_remove', 'pass'])
+  })
+
+  test('load-bearing FAMILY_DISPATCHER_NAMES filter: synthesised dispatcher appears ONCE, never twice', () => {
+    // The filter in accept() prevents projection-time duplicate-function
+    // declarations on Gemini (commit b0fe8d3 was the prior incident).
+    // This test models a registry that contains BOTH the family members
+    // AND a real tool that happens to share the dispatcher name
+    // (e.g. a pack registers a tool called geo_tools, or — historically —
+    // a previous spawn's dispatcher registration left geo_tools in the
+    // registry). The projection must emit geo_tools exactly once.
+    const r = createToolRegistry()
+    for (const n of ['geo_lookup', 'geo_add', 'geo_remove']) r.register(mockTool(n, 100))
+    r.register(mockTool('geo_tools', 100))   // colliding atomic registration
+    r.register(createPassTool())
+
+    const surface = createToolSurface({
+      registry: r,
+      requestedTools: r.list().map(t => t.name),
+    })
+    const compressed = surface.project(undefined, 'openai')
+    const names = compressed.map(d => d.function.name)
+    expect(names.filter(n => n === 'geo_tools').length).toBe(1)
+  })
+})
+
 describe('getRegistryDispatchers', () => {
   test('returns one trampoline per family in BUILT_IN_FAMILIES, regardless of current member count', () => {
     // Pre-trampoline this returned only "compressible-now" families; with


### PR DESCRIPTION
## Summary

Prod observation today on gpt-5.4 in the Cafe room: \`tool_loop_exceeded\` on every map request. SSH log showed:

\`\`\`
[spawn] Agent "AI": tools not found in registry: geo_tools, pack_admin, codegen_tools
\`\`\`

**Root cause**: pre-trampoline-refactor (2026-05) snapshots captured family dispatcher names (\`geo_tools\`, \`pack_admin\`, \`codegen_tools\`, \`fs\`) in \`agent.config.tools\` — they were "real" registered tools at the time. Post-refactor:

- Dispatchers are synthesised at projection time, not requested
- \`FAMILY_DISPATCHER_NAMES\` are filtered out of candidates universally
- \`compressFamilies\` needs MEMBERS in candidates to fire

An agent whose stored \`config.tools\` contained only dispatcher names (plus a few atomics) ended up with an EMPTY geo capability. The LLM saw \`pass\` only and looped until the iteration cap.

## Approach (stress-tested)

Initial Plan 1 was an architectural split (separate \`DispatcherOverlay\` from main registry). Stress-test concluded it was over-engineered for this bug class: ~3× the LOC, moves the conflict from "shared namespace" to "two-namespace consistency," same fragility surface. **Plan 2 — runtime expansion only** picked instead.

Three changes:

1. **\`expandFamilyAliases\`** in [tool-surface/index.ts](src/tool-surface/index.ts): when a dispatcher name appears in \`requestedTools\`, expand to the family's underlying member names at surface-construction time. Self-heals on every load; no snapshot migration (would violate the project's clean-break snapshot policy).

2. **\`FAMILY_DISPATCHER_NAMES\` filter** in \`accept()\` retained as LOAD-BEARING — still the last-line defence against the Gemini "Duplicate function declaration" failure mode ([b0fe8d3](../../commit/b0fe8d3)). Comment expanded so a future reader doesn't remove it as redundant.

3. **\`warnMissingTools\`** in [spawn.ts](src/agents/spawn.ts) now skips dispatcher names — they're expected to be absent from the registry as atomic entries. The boot warning misled debugging today; quieting it.

## Test plan

- [x] \`bun run check\`
- [x] \`bun run test:unit\` — 1305 pass / 0 fail (+1 over baseline)
- [x] Dispatcher name in requestedTools → compression fires (geo_tools dispatcher in surface)
- [x] Member names directly → regression guard, normal case unchanged
- [x] Dispatcher + Gemini strict path → flat surface has underlying members
- [x] Atomic geo_tools sharing dispatcher name → projection emits geo_tools EXACTLY ONCE (load-bearing filter regression)
- [ ] Manual after deploy: in the Cafe room (or any room with the stale snapshot), ask gpt-5.4 "show norwegian oil platforms on map" → single \`geo_list_features\` call, map renders inline. No boot warning about missing dispatcher names.

## What this does NOT solve (deferred)

- Model behaviour issues (gpt-5-mini permission-asking pattern) — separate problem
- \`config.tools\` storing concrete names rather than intent (Plan B/C) — bigger refactor
- Overlay-split architectural separation — rejected after stress-test in favour of this scoped fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)